### PR TITLE
Prevent starting/ending the audio session two times in a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Improve chat example UI: add validation and rename fields
 * Add narracted actions support
+* Prevent starting/ending the audio session two times in a row
 
 ## 2022-03-31 v0.9.6
 

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -67,6 +67,6 @@ describe('should throw error', () => {
   test('on empty scene', async () => {
     const inworldClient = new InworldClient().setScene('');
 
-    await expect(() => inworldClient.build()).toThrow('Scene name is required');
+    expect(() => inworldClient.build()).toThrow('Scene name is required');
   });
 });

--- a/__tests__/services/inworld_connection.service.spec.ts
+++ b/__tests__/services/inworld_connection.service.spec.ts
@@ -3,7 +3,7 @@ import '../mocks/window.mock';
 import { v4 } from 'uuid';
 
 import { DataChunkDataType } from '../../proto/packets.pb';
-import { AudioSessionAction } from '../../src/common/interfaces';
+import { AudioSessionState } from '../../src/common/interfaces';
 import { InworldHistory } from '../../src/components/history';
 import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../../src/components/sound/grpc_audio.recorder';
@@ -269,7 +269,7 @@ describe('send', () => {
   test('should send audio session start', async () => {
     jest
       .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
-      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+      .mockImplementationOnce(() => AudioSessionState.UNKNOWN);
     const write = jest
       .spyOn(WebSocketConnection.prototype, 'write')
       .mockImplementationOnce(writeMock);
@@ -287,7 +287,7 @@ describe('send', () => {
       .mockImplementationOnce(writeMock);
     jest
       .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
-      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+      .mockImplementationOnce(() => AudioSessionState.UNKNOWN);
 
     await service.sendAudioSessionStart();
 
@@ -302,7 +302,7 @@ describe('send', () => {
       .mockImplementationOnce(writeMock);
     jest
       .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
-      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+      .mockImplementationOnce(() => AudioSessionState.UNKNOWN);
 
     await service.sendAudioSessionStart();
     await service.sendAudioSessionEnd();
@@ -321,7 +321,7 @@ describe('send', () => {
       .mockImplementationOnce(writeMock);
     jest
       .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
-      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+      .mockImplementationOnce(() => AudioSessionState.UNKNOWN);
 
     await service.sendAudioSessionStart();
     const packet = await service.sendAudioSessionEnd();

--- a/__tests__/services/inworld_connection.service.spec.ts
+++ b/__tests__/services/inworld_connection.service.spec.ts
@@ -3,6 +3,7 @@ import '../mocks/window.mock';
 import { v4 } from 'uuid';
 
 import { DataChunkDataType } from '../../proto/packets.pb';
+import { AudioSessionAction } from '../../src/common/interfaces';
 import { InworldHistory } from '../../src/components/history';
 import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../../src/components/sound/grpc_audio.recorder';
@@ -266,6 +267,9 @@ describe('send', () => {
   });
 
   test('should send audio session start', async () => {
+    jest
+      .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
+      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
     const write = jest
       .spyOn(WebSocketConnection.prototype, 'write')
       .mockImplementationOnce(writeMock);
@@ -277,15 +281,53 @@ describe('send', () => {
     expect(packet.isControl()).toEqual(true);
   });
 
+  test('should throw error if audio session was started twice', async () => {
+    jest
+      .spyOn(WebSocketConnection.prototype, 'write')
+      .mockImplementationOnce(writeMock);
+    jest
+      .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
+      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+
+    await service.sendAudioSessionStart();
+
+    expect(async () => {
+      await service.sendAudioSessionStart();
+    }).rejects.toThrow('Audio session is already started');
+  });
+
+  test('should throw error if audio session was finished twice', async () => {
+    jest
+      .spyOn(WebSocketConnection.prototype, 'write')
+      .mockImplementationOnce(writeMock);
+    jest
+      .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
+      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
+
+    await service.sendAudioSessionStart();
+    await service.sendAudioSessionEnd();
+
+    expect(async () => {
+      await service.sendAudioSessionEnd();
+    }).rejects.toThrow(
+      'Audio session cannot be ended because it has not been started',
+    );
+  });
+
   test('should send audio session end', async () => {
     const write = jest
       .spyOn(WebSocketConnection.prototype, 'write')
+      .mockImplementationOnce(writeMock)
       .mockImplementationOnce(writeMock);
+    jest
+      .spyOn(ConnectionService.prototype, 'getAudioSessionAction')
+      .mockImplementationOnce(() => AudioSessionAction.UNKNOWN);
 
+    await service.sendAudioSessionStart();
     const packet = await service.sendAudioSessionEnd();
 
     expect(open).toHaveBeenCalledTimes(0);
-    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(2);
     expect(packet.isControl()).toEqual(true);
   });
 

--- a/examples/chat/src/app/chat/Chat.tsx
+++ b/examples/chat/src/app/chat/Chat.tsx
@@ -160,7 +160,6 @@ export function Chat(props: ChatProps) {
 
     if (isRecording) {
       stopRecording();
-      connection.sendAudioSessionEnd();
       setIsRecording(false);
       return;
     }

--- a/examples/chat/src/app/chat/Chat.tsx
+++ b/examples/chat/src/app/chat/Chat.tsx
@@ -118,11 +118,13 @@ export function Chat(props: ChatProps) {
     connection.recorder.stop();
     setIsRecording(false);
     connection.sendAudioSessionEnd();
+    console.log('sendAudioSessionEnd');
   }, [connection]);
 
   const startRecording = useCallback(async () => {
     try {
       connection.sendAudioSessionStart();
+      console.log('sendAudioSessionStart');
       await connection.recorder.start();
       setIsRecording(true);
     } catch (e) {
@@ -159,9 +161,7 @@ export function Chat(props: ChatProps) {
     !hasPlayedWorkaroundSound && playWorkaroundSound();
 
     if (isRecording) {
-      stopRecording();
-      setIsRecording(false);
-      return;
+      return stopRecording();
     }
 
     return startRecording();

--- a/examples/chat/src/app/chat/Chat.tsx
+++ b/examples/chat/src/app/chat/Chat.tsx
@@ -118,13 +118,11 @@ export function Chat(props: ChatProps) {
     connection.recorder.stop();
     setIsRecording(false);
     connection.sendAudioSessionEnd();
-    console.log('sendAudioSessionEnd');
   }, [connection]);
 
   const startRecording = useCallback(async () => {
     try {
       connection.sendAudioSessionStart();
-      console.log('sendAudioSessionStart');
       await connection.recorder.start();
       setIsRecording(true);
     } catch (e) {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -70,3 +70,9 @@ export enum ConnectionState {
   LOADING = 'LOADING',
   INACTIVE = 'INACTIVE',
 }
+
+export enum AudioSessionAction {
+  UNKNOWN = 'UNKNOWN',
+  START = 'START',
+  END = 'END',
+}

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -71,7 +71,7 @@ export enum ConnectionState {
   INACTIVE = 'INACTIVE',
 }
 
-export enum AudioSessionAction {
+export enum AudioSessionState {
   UNKNOWN = 'UNKNOWN',
   START = 'START',
   END = 'END',

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -6,7 +6,7 @@ import {
   UserRequest,
 } from '../../proto/world-engine.pb';
 import {
-  AudioSessionAction,
+  AudioSessionState,
   Awaitable,
   CancelResponses,
   CancelResponsesProps,
@@ -54,7 +54,7 @@ const player = Player.getInstance();
 
 export class ConnectionService {
   private state: ConnectionState = ConnectionState.INACTIVE;
-  private audioSessionAction = AudioSessionAction.UNKNOWN;
+  private audioSessionAction = AudioSessionState.UNKNOWN;
 
   private scene: LoadSceneResponse;
   private session: SessionToken;
@@ -167,7 +167,7 @@ export class ConnectionService {
     }
   }
 
-  setAudioSessionAction(action: AudioSessionAction) {
+  setAudioSessionAction(action: AudioSessionState) {
     this.audioSessionAction = action;
   }
 
@@ -333,7 +333,7 @@ export class ConnectionService {
 
     this.onDisconnect = () => {
       this.state = ConnectionState.INACTIVE;
-      this.audioSessionAction = AudioSessionAction.UNKNOWN;
+      this.audioSessionAction = AudioSessionState.UNKNOWN;
       onDisconnect?.();
     };
 

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -6,6 +6,7 @@ import {
   UserRequest,
 } from '../../proto/world-engine.pb';
 import {
+  AudioSessionAction,
   Awaitable,
   CancelResponses,
   CancelResponsesProps,
@@ -53,6 +54,7 @@ const player = Player.getInstance();
 
 export class ConnectionService {
   private state: ConnectionState = ConnectionState.INACTIVE;
+  private audioSessionAction = AudioSessionAction.UNKNOWN;
 
   private scene: LoadSceneResponse;
   private session: SessionToken;
@@ -169,6 +171,14 @@ export class ConnectionService {
     } catch (err) {
       this.onError(err);
     }
+  }
+
+  setAudioSessionAction(action: AudioSessionAction) {
+    this.audioSessionAction = action;
+  }
+
+  getAudioSessionAction() {
+    return this.audioSessionAction;
   }
 
   private async loadCharactersList() {
@@ -321,6 +331,7 @@ export class ConnectionService {
 
     this.onDisconnect = () => {
       this.state = ConnectionState.INACTIVE;
+      this.audioSessionAction = AudioSessionAction.UNKNOWN;
       onDisconnect?.();
     };
 

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -1,5 +1,5 @@
 import { DataChunkDataType } from '../../proto/packets.pb';
-import { AudioSessionAction, CancelResponsesProps } from '../common/interfaces';
+import { AudioSessionState, CancelResponsesProps } from '../common/interfaces';
 import { GrpcAudioPlayback } from '../components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../components/sound/grpc_audio.recorder';
 import { GrpcWebRtcLoopbackBiDiSession } from '../components/sound/grpc_web_rtc_loopback_bidi.session';
@@ -34,7 +34,7 @@ export class InworldConnectionService {
         if (
           !this.connection.isActive() &&
           this.connection.isAutoReconnected() &&
-          this.connection.getAudioSessionAction() !== AudioSessionAction.START
+          this.connection.getAudioSessionAction() !== AudioSessionState.START
         ) {
           await this.sendAudioSessionStart();
         }
@@ -102,11 +102,11 @@ export class InworldConnectionService {
   }
 
   async sendAudioSessionStart() {
-    if (this.connection.getAudioSessionAction() === AudioSessionAction.START) {
+    if (this.connection.getAudioSessionAction() === AudioSessionState.START) {
       throw Error('Audio session is already started');
     }
 
-    this.connection.setAudioSessionAction(AudioSessionAction.START);
+    this.connection.setAudioSessionAction(AudioSessionState.START);
 
     return this.connection.send(() =>
       this.connection.getEventFactory().audioSessionStart(),
@@ -114,13 +114,13 @@ export class InworldConnectionService {
   }
 
   async sendAudioSessionEnd() {
-    if (this.connection.getAudioSessionAction() !== AudioSessionAction.START) {
+    if (this.connection.getAudioSessionAction() !== AudioSessionState.START) {
       throw Error(
         'Audio session cannot be ended because it has not been started',
       );
     }
 
-    this.connection.setAudioSessionAction(AudioSessionAction.END);
+    this.connection.setAudioSessionAction(AudioSessionState.END);
 
     return this.connection.send(() =>
       this.connection.getEventFactory().audioSessionEnd(),

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -31,7 +31,11 @@ export class InworldConnectionService {
     });
     this.recorder = new InworldRecorder({
       listener: async (base64AudioChunk: string) => {
-        if (!this.connection.isActive()) {
+        if (
+          !this.connection.isActive() &&
+          this.connection.isAutoReconnected() &&
+          this.connection.getAudioSessionAction() !== AudioSessionAction.START
+        ) {
           await this.sendAudioSessionStart();
         }
 

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -1,5 +1,5 @@
 import { DataChunkDataType } from '../../proto/packets.pb';
-import { CancelResponsesProps } from '../common/interfaces';
+import { AudioSessionAction, CancelResponsesProps } from '../common/interfaces';
 import { GrpcAudioPlayback } from '../components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../components/sound/grpc_audio.recorder';
 import { GrpcWebRtcLoopbackBiDiSession } from '../components/sound/grpc_web_rtc_loopback_bidi.session';
@@ -98,12 +98,26 @@ export class InworldConnectionService {
   }
 
   async sendAudioSessionStart() {
+    if (this.connection.getAudioSessionAction() === AudioSessionAction.START) {
+      throw Error('Audio session is already started');
+    }
+
+    this.connection.setAudioSessionAction(AudioSessionAction.START);
+
     return this.connection.send(() =>
       this.connection.getEventFactory().audioSessionStart(),
     );
   }
 
   async sendAudioSessionEnd() {
+    if (this.connection.getAudioSessionAction() !== AudioSessionAction.START) {
+      throw Error(
+        'Audio session cannot be ended because it has not been started',
+      );
+    }
+
+    this.connection.setAudioSessionAction(AudioSessionAction.END);
+
     return this.connection.send(() =>
       this.connection.getEventFactory().audioSessionEnd(),
     );


### PR DESCRIPTION
If `sendAudioSessionStart` is called twice in a row, the server produces an error (without providing any details to the user)
It should be checked on the client side