### PR TITLE
Allow to extend packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Allow to use extended capabilities
+* Allow to send and receive custom proto packet
+
 ## 2022-05-01 v1.1.0
 
 * Allow to interrupt character manually

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Allow to use extended capabilities
+* Allow to use extended capabilities and scene props
 * Allow to send and receive custom proto packet
 
 ## 2022-05-01 v1.1.0

--- a/__tests__/components/history.spec.ts
+++ b/__tests__/components/history.spec.ts
@@ -2,6 +2,7 @@ import '../mocks/window.mock';
 
 import { v4 } from 'uuid';
 
+import { protoTimestamp } from '../../src/common/helpers';
 import {
   CHAT_HISTORY_TYPE,
   HistoryItemActor,
@@ -38,7 +39,7 @@ const routing: Routing = {
     isCharacter: true,
   },
 };
-const date = new Date().toISOString();
+const date = protoTimestamp();
 const grpcAudioPlayer = new GrpcAudioPlayback();
 const textPacket = new InworldPacket({
   packetId,

--- a/__tests__/components/sound/grpc_audio.playback.spec.ts
+++ b/__tests__/components/sound/grpc_audio.playback.spec.ts
@@ -4,10 +4,10 @@ import { v4 } from 'uuid';
 
 import { DataChunkDataType } from '../../../proto/packets.pb';
 import { GrpcAudioPlayback } from '../../../src/components/sound/grpc_audio.playback';
-import { EventFactory } from '../../../src/factories/event';
+import { InworldPacket } from '../../../src/entities/inworld_packet.entity';
 import { getPacketId } from '../../helpers';
 
-const audioEvent = EventFactory.fromProto({
+const audioEvent = InworldPacket.fromProto({
   dataChunk: {
     chunk: v4() as unknown as Uint8Array,
     type: DataChunkDataType.AUDIO,

--- a/__tests__/connection/web-socket.connection.spec.ts
+++ b/__tests__/connection/web-socket.connection.spec.ts
@@ -162,7 +162,9 @@ describe('write', () => {
 describe('close', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
 
+  test('should open and close connection', async () => {
     ws = new WebSocketConnection({
       config: {
         connection: { gateway: { hostname: HOSTNAME } },
@@ -172,15 +174,26 @@ describe('close', () => {
       onReady,
       onDisconnect,
     });
-  });
 
-  test('should not throw error', async () => {
     ws.open({ session });
     ws.write({
       getPacket: () => textMessage,
     });
 
     await server.connected;
+
+    expect(() => ws.close()).not.toThrow();
+  });
+
+  test('should not throw error if connection is not open before', async () => {
+    ws = new WebSocketConnection({
+      config: {
+        connection: { gateway: { hostname: HOSTNAME } },
+        capabilities: capabilitiesProps,
+      },
+      onError,
+      onReady,
+    });
 
     expect(() => ws.close()).not.toThrow();
   });

--- a/__tests__/data_structures.ts
+++ b/__tests__/data_structures.ts
@@ -1,0 +1,23 @@
+import { CapabilitiesRequest } from '../proto/world-engine.pb';
+import { Capabilities } from '../src/common/data_structures';
+import { InworldPacket } from '../src/entities/inworld_packet.entity';
+
+export interface ExtendedCapabilities extends Capabilities {
+  regenerateResponse: boolean;
+}
+
+export interface ExtendedCapabilitiesRequest extends CapabilitiesRequest {
+  regenerateResponse: boolean;
+}
+
+export interface RegenerateResponse {
+  interactionId?: string;
+}
+
+export interface MutationEvent {
+  regenerateResponse?: RegenerateResponse;
+}
+
+export interface ExtendedInworldPacket extends InworldPacket {
+  mutation: MutationEvent;
+}

--- a/__tests__/entities/inworld_packet.entity.spec.ts
+++ b/__tests__/entities/inworld_packet.entity.spec.ts
@@ -1,5 +1,6 @@
 import { v4 } from 'uuid';
 
+import { protoTimestamp } from '../../src/common/helpers';
 import {
   AudioEvent,
   InworlControlType,
@@ -23,7 +24,7 @@ const routing: Routing = {
     isCharacter: true,
   },
 };
-const date = new Date().toISOString();
+const date = protoTimestamp();
 
 test('should get audio packet fields', () => {
   const audio: AudioEvent = {

--- a/__tests__/factories/event.spec.ts
+++ b/__tests__/factories/event.spec.ts
@@ -215,28 +215,28 @@ describe('convert packet to external one', () => {
       timestamp: protoTimestamp(),
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isAudio()).toEqual(true);
   });
 
   test('text', () => {
-    const result = EventFactory.fromProto(factory.text(v4()));
+    const result = InworldPacket.fromProto(factory.text(v4()));
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isText()).toEqual(true);
   });
 
   test('trigger without parameters', () => {
-    const result = EventFactory.fromProto(factory.trigger(v4()));
+    const result = InworldPacket.fromProto(factory.trigger(v4()));
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isTrigger()).toEqual(true);
   });
 
   test('trigger with parameters', () => {
-    const result = EventFactory.fromProto(
+    const result = InworldPacket.fromProto(
       factory.trigger(v4(), [{ name: v4(), value: v4() }]),
     );
 
@@ -255,7 +255,7 @@ describe('convert packet to external one', () => {
       timestamp: protoTimestamp(),
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isEmotion()).toEqual(true);
@@ -272,7 +272,7 @@ describe('convert packet to external one', () => {
       timestamp: protoTimestamp(),
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isSilence()).toEqual(true);
@@ -289,7 +289,7 @@ describe('convert packet to external one', () => {
       timestamp: protoTimestamp(),
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isCancelResponse()).toEqual(true);
@@ -309,7 +309,7 @@ describe('convert packet to external one', () => {
       },
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isNarratedAction()).toEqual(true);
@@ -325,7 +325,7 @@ describe('convert packet to external one', () => {
       timestamp: protoTimestamp(),
     };
 
-    const result = EventFactory.fromProto(packet);
+    const result = InworldPacket.fromProto(packet);
 
     expect(result).toBeInstanceOf(InworldPacket);
     expect(result.isEmotion()).toEqual(false);
@@ -350,7 +350,7 @@ describe('convert packet to external one', () => {
         timestamp: protoTimestamp(today),
       };
 
-      const result = EventFactory.fromProto(packet);
+      const result = InworldPacket.fromProto(packet);
 
       expect(result).toBeInstanceOf(InworldPacket);
       expect(result.isControl()).toEqual(true);
@@ -371,7 +371,7 @@ describe('convert packet to external one', () => {
         timestamp: protoTimestamp(today),
       };
 
-      const result = EventFactory.fromProto(packet);
+      const result = InworldPacket.fromProto(packet);
 
       expect(result).toBeInstanceOf(InworldPacket);
       expect(result.isControl()).toEqual(true);

--- a/__tests__/factories/event.spec.ts
+++ b/__tests__/factories/event.spec.ts
@@ -6,13 +6,12 @@ import {
   DataChunkDataType,
   InworldPacket as ProtoPacket,
 } from '../../proto/packets.pb';
+import { protoTimestamp } from '../../src/common/helpers';
 import { InworldPacket } from '../../src/entities/inworld_packet.entity';
 import { EventFactory } from '../../src/factories/event';
 import { createCharacter } from '../helpers';
 
 let factory: EventFactory;
-
-const protoTimestamp = (date?: Date) => (date || new Date()).toISOString();
 
 beforeEach(() => {
   factory = new EventFactory();

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,6 +1,7 @@
 import { v4 } from 'uuid';
 
 import { LoadSceneResponseAgent } from '../proto/world-engine.pb';
+import { protoTimestamp } from '../src/common/helpers';
 import {
   Capabilities,
   Client,
@@ -11,8 +12,8 @@ import { QueueItem } from '../src/connection/web-socket.connection';
 import { Character } from '../src/entities/character.entity';
 import { PacketId } from '../src/entities/inworld_packet.entity';
 
-const today = new Date();
-today.setHours(today.getHours() + 1);
+const inOneHours = new Date();
+inOneHours.setHours(inOneHours.getHours() + 1);
 
 export const SCENE = v4();
 
@@ -56,7 +57,7 @@ export const session: SessionToken = {
   sessionId: v4(),
   token: v4(),
   type: 'Bearer',
-  expirationTime: today.toISOString(),
+  expirationTime: protoTimestamp(inOneHours),
 };
 
 export const generateSessionToken = () => Promise.resolve(session);

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,13 +1,13 @@
 import { v4 } from 'uuid';
 
 import { LoadSceneResponseAgent } from '../proto/world-engine.pb';
-import { protoTimestamp } from '../src/common/helpers';
 import {
   Capabilities,
   Client,
   SessionToken,
   User,
-} from '../src/common/interfaces';
+} from '../src/common/data_structures';
+import { protoTimestamp } from '../src/common/helpers';
 import { QueueItem } from '../src/connection/web-socket.connection';
 import { Character } from '../src/entities/character.entity';
 import { PacketId } from '../src/entities/inworld_packet.entity';

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,5 +1,6 @@
 import { v4 } from 'uuid';
 
+import { InworldPacket as ProtoPacket } from '../proto/packets.pb';
 import { LoadSceneResponseAgent } from '../proto/world-engine.pb';
 import {
   Capabilities,
@@ -10,7 +11,12 @@ import {
 import { protoTimestamp } from '../src/common/helpers';
 import { QueueItem } from '../src/connection/web-socket.connection';
 import { Character } from '../src/entities/character.entity';
-import { PacketId } from '../src/entities/inworld_packet.entity';
+import { InworldPacket, PacketId } from '../src/entities/inworld_packet.entity';
+import {
+  ExtendedCapabilities,
+  ExtendedCapabilitiesRequest,
+  ExtendedInworldPacket,
+} from './data_structures';
 
 const inOneHours = new Date();
 inOneHours.setHours(inOneHours.getHours() + 1);
@@ -72,6 +78,24 @@ export const capabilitiesProps: Capabilities = {
   turnBasedStt: true,
 };
 
+export const extendedCapabilitiesProps: ExtendedCapabilities = {
+  ...capabilitiesProps,
+  regenerateResponse: true,
+};
+
+export const extendedCapabilitiesRequestProps: ExtendedCapabilitiesRequest = {
+  audio: true,
+  emotions: true,
+  interruptions: true,
+  phonemeInfo: true,
+  silenceEvents: true,
+  narratedActions: true,
+  text: true,
+  triggers: true,
+  turnBasedStt: true,
+  regenerateResponse: true,
+};
+
 export const user: User = {
   fullName: 'Full Name',
   id: 'id',
@@ -90,3 +114,13 @@ export const getPacketId = (): PacketId => ({
   interactionId: v4(),
   utteranceId: v4(),
 });
+
+export const extension = {
+  convertPacketFromProto: (proto: ProtoPacket) => {
+    const packet = InworldPacket.fromProto(proto) as ExtendedInworldPacket;
+
+    packet.mutation = proto.mutation;
+
+    return packet;
+  },
+};

--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -8,8 +8,8 @@ import {
   DataChunkDataType,
   InworldPacket as ProtoPacket,
 } from '../../proto/packets.pb';
+import { SessionToken } from '../../src/common/data_structures';
 import { protoTimestamp } from '../../src/common/helpers';
-import { SessionToken } from '../../src/common/interfaces';
 import {
   CHAT_HISTORY_TYPE,
   HistoryItem,

--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -18,6 +18,7 @@ import {
 import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
 import { GrpcWebRtcLoopbackBiDiSession } from '../../src/components/sound/grpc_web_rtc_loopback_bidi.session';
 import { WebSocketConnection } from '../../src/connection/web-socket.connection';
+import { InworldPacket } from '../../src/entities/inworld_packet.entity';
 import { EventFactory } from '../../src/factories/event';
 import { ConnectionService } from '../../src/services/connection.service';
 import { WorldEngineService } from '../../src/services/world_engine.service';
@@ -483,7 +484,7 @@ describe('send', () => {
     jest
       .spyOn(GrpcAudioPlayback.prototype, 'excludeCurrentInteractionPackets')
       .mockImplementationOnce(() => [
-        EventFactory.fromProto({
+        InworldPacket.fromProto({
           ...audioEvent,
           packetId: {
             packetId: audioEvent.packetId.packetId,
@@ -560,7 +561,7 @@ describe('onMessage', () => {
     jest
       .spyOn(GrpcAudioPlayback.prototype, 'excludeCurrentInteractionPackets')
       .mockImplementationOnce(() => [
-        EventFactory.fromProto({
+        InworldPacket.fromProto({
           ...audioEvent,
           packetId: {
             ...textEvent.packetId,
@@ -590,7 +591,7 @@ describe('onMessage', () => {
     jest
       .spyOn(GrpcAudioPlayback.prototype, 'excludeCurrentInteractionPackets')
       .mockImplementationOnce(() => [
-        EventFactory.fromProto({
+        InworldPacket.fromProto({
           ...audioEvent,
           packetId: {
             ...textEvent.packetId,

--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -8,6 +8,7 @@ import {
   DataChunkDataType,
   InworldPacket as ProtoPacket,
 } from '../../proto/packets.pb';
+import { protoTimestamp } from '../../src/common/helpers';
 import { SessionToken } from '../../src/common/interfaces';
 import {
   CHAT_HISTORY_TYPE,
@@ -259,7 +260,7 @@ describe('open', () => {
       sessionId: v4(),
       token: v4(),
       type: 'Bearer',
-      expirationTime: new Date().toISOString(),
+      expirationTime: protoTimestamp(),
     };
 
     const generateSessionToken = jest.fn(() => Promise.resolve(expiredSession));

--- a/__tests__/services/inworld_connection.service.spec.ts
+++ b/__tests__/services/inworld_connection.service.spec.ts
@@ -3,8 +3,8 @@ import '../mocks/window.mock';
 import { v4 } from 'uuid';
 
 import { DataChunkDataType } from '../../proto/packets.pb';
+import { AudioSessionState } from '../../src/common/data_structures';
 import { protoTimestamp } from '../../src/common/helpers';
-import { AudioSessionState } from '../../src/common/interfaces';
 import { InworldHistory } from '../../src/components/history';
 import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../../src/components/sound/grpc_audio.recorder';

--- a/__tests__/services/inworld_connection.service.spec.ts
+++ b/__tests__/services/inworld_connection.service.spec.ts
@@ -3,6 +3,7 @@ import '../mocks/window.mock';
 import { v4 } from 'uuid';
 
 import { DataChunkDataType } from '../../proto/packets.pb';
+import { protoTimestamp } from '../../src/common/helpers';
 import { AudioSessionState } from '../../src/common/interfaces';
 import { InworldHistory } from '../../src/components/history';
 import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
@@ -165,7 +166,7 @@ describe('history', () => {
         isCharacter: true,
       },
     };
-    const date = new Date().toISOString();
+    const date = protoTimestamp();
     const packet = new InworldPacket({
       packetId,
       routing,

--- a/examples/chat/src/App.tsx
+++ b/examples/chat/src/App.tsx
@@ -109,7 +109,7 @@ function App() {
     if (character) {
       service.connection.setCurrentCharacter(character);
 
-      const assets = character?.getAssets();
+      const assets = character?.assets;
       const rpmImageUri = assets?.rpmImageUriPortrait;
       const avatarImg = assets?.avatarImg;
       setAvatar(avatarImg || rpmImageUri || '');
@@ -170,7 +170,7 @@ function App() {
               visible={chatView === CHAT_VIEW.AVATAR}
               url={
                 config.RPM_AVATAR ||
-                character.getAssets().rpmModelUri ||
+                character.assets.rpmModelUri ||
                 defaults.DEFAULT_RPM_AVATAR
               }
             />

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,7 @@
 {
   "coveragePathIgnorePatterns": ["/node_modules/", "proto"],
   "modulePathIgnorePatterns": [
+    "__tests__/data_structures.ts",
     "__tests__/helpers.ts",
     "__tests__/mocks/"
   ],

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -1,5 +1,8 @@
 import { InworldPacket as ProtoPacket } from '../../proto/packets.pb';
-import { CapabilitiesRequest } from '../../proto/world-engine.pb';
+import {
+  CapabilitiesRequest,
+  LoadSceneRequest,
+} from '../../proto/world-engine.pb';
 import { AdditionalPhonemeInfo } from '../entities/inworld_packet.entity';
 
 export interface Capabilities {
@@ -78,6 +81,12 @@ export enum AudioSessionState {
   END = 'END',
 }
 
+export type ExtensionLoadSceneProps = Omit<
+  LoadSceneRequest,
+  'name' | 'capabilities' | 'user' | 'client'
+>;
+
 export interface Extension<InworldPacketT> {
-  convertPacketFromProto: (proto: ProtoPacket) => InworldPacketT;
+  convertPacketFromProto?: (proto: ProtoPacket) => InworldPacketT;
+  loadSceneProps?: ExtensionLoadSceneProps;
 }

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -1,3 +1,4 @@
+import { InworldPacket as ProtoPacket } from '../../proto/packets.pb';
 import { CapabilitiesRequest } from '../../proto/world-engine.pb';
 import { AdditionalPhonemeInfo } from '../entities/inworld_packet.entity';
 
@@ -37,9 +38,9 @@ export interface ConnectionConfig {
   disconnectTimeout?: number;
   gateway?: Gateway;
 }
-export interface ClientConfiguration {
+export interface ClientConfiguration<CapabilitiesT> {
   connection?: ConnectionConfig;
-  capabilities?: Capabilities;
+  capabilities?: CapabilitiesT;
 }
 
 export interface InternalClientConfiguration {
@@ -75,4 +76,8 @@ export enum AudioSessionState {
   UNKNOWN = 'UNKNOWN',
   START = 'START',
   END = 'END',
+}
+
+export interface Extension<InworldPacketT> {
+  convertPacketFromProto: (proto: ProtoPacket) => InworldPacketT;
 }

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -1,0 +1,2 @@
+export const protoTimestamp = (date?: Date) =>
+  (date || new Date()).toISOString();

--- a/src/components/history.ts
+++ b/src/components/history.ts
@@ -10,10 +10,10 @@ import {
 } from '../entities/inworld_packet.entity';
 import { GrpcAudioPlayback } from './sound/grpc_audio.playback';
 
-interface InworldHistoryAddProps {
+interface InworldHistoryAddProps<InworldPacketT> {
   characters: Character[];
   grpcAudioPlayer: GrpcAudioPlayback;
-  packet: InworldPacket;
+  packet: InworldPacketT;
   outgoing?: boolean;
 }
 
@@ -66,7 +66,9 @@ interface EmotionsMap {
   [key: string]: EmotionEvent;
 }
 
-export class InworldHistory {
+export class InworldHistory<
+  InworldPacketT extends InworldPacket = InworldPacket,
+> {
   private history: HistoryItem[] = [];
   private queue: HistoryItem[] = [];
   private emotions: EmotionsMap = {};
@@ -76,7 +78,7 @@ export class InworldHistory {
     grpcAudioPlayer,
     packet,
     outgoing,
-  }: InworldHistoryAddProps) {
+  }: InworldHistoryAddProps<InworldPacketT>) {
     let chatItem: HistoryItem | undefined;
 
     const utteranceId = packet.packetId?.utteranceId;
@@ -142,7 +144,7 @@ export class InworldHistory {
     return !!chatItem;
   }
 
-  update(packet: InworldPacket) {
+  update(packet: InworldPacketT) {
     if (packet.isText()) {
       const currentHistoryIndex = this.history.findIndex(
         (item) => item.id === packet.packetId?.utteranceId,
@@ -162,7 +164,7 @@ export class InworldHistory {
   }
 
   display(
-    packet: InworldPacket,
+    packet: InworldPacketT,
     type:
       | CHAT_HISTORY_TYPE.ACTOR
       | CHAT_HISTORY_TYPE.INTERACTION_END
@@ -279,7 +281,7 @@ export class InworldHistory {
     return transcript;
   }
 
-  private combineTextItem(packet: InworldPacket): HistoryItemActor {
+  private combineTextItem(packet: InworldPacketT): HistoryItemActor {
     const date = new Date(packet.date);
     const source = packet.routing?.source;
     const utteranceId = packet.packetId?.utteranceId;
@@ -297,7 +299,7 @@ export class InworldHistory {
   }
 
   private combineNarratedActionItem(
-    packet: InworldPacket,
+    packet: InworldPacketT,
   ): HistoryItemNarratedAction {
     const date = new Date(packet.date);
     const interactionId = packet.packetId?.interactionId;
@@ -313,7 +315,7 @@ export class InworldHistory {
   }
 
   private combineTriggerItem(
-    packet: InworldPacket,
+    packet: InworldPacketT,
     outgoing?: boolean,
   ): HistoryItemTriggerEvent {
     const date = new Date(packet.date);
@@ -333,7 +335,7 @@ export class InworldHistory {
   }
 
   private combineInteractionEndItem(
-    packet: InworldPacket,
+    packet: InworldPacketT,
   ): HistoryInteractionEnd {
     const date = new Date(packet.date);
     const interactionId = packet.packetId?.interactionId;

--- a/src/components/sound/player.ts
+++ b/src/components/sound/player.ts
@@ -24,10 +24,7 @@ export class Player {
   }
 
   getMute(): boolean {
-    if (this.audioElement) {
-      return this.audioElement.muted;
-    }
-    return false;
+    return this.audioElement.muted;
   }
 
   setStream(stream: MediaStream) {

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -4,7 +4,7 @@ import {
   InternalClientConfiguration,
   SessionToken,
   VoidFn,
-} from '../common/interfaces';
+} from '../common/data_structures';
 
 const SESSION_PATH = '/v1/session/default';
 

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -69,10 +69,6 @@ export class WebSocketConnection implements Connection {
   }
 
   close() {
-    if (this.connectionProps.onReady) {
-      this.ws?.removeEventListener('open', this.onReady);
-    }
-
     if (this.connectionProps.onError) {
       this.ws?.removeEventListener('error', this.connectionProps.onError);
     }
@@ -81,6 +77,7 @@ export class WebSocketConnection implements Connection {
       this.ws?.removeEventListener('close', this.connectionProps.onDisconnect);
     }
 
+    this.ws?.removeEventListener('open', this.onReady);
     this.ws?.removeEventListener('message', this.onMessage);
 
     if (this.isActive()) {

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -91,7 +91,7 @@ export class WebSocketConnection<
     this.ws?.removeEventListener('message', this.onMessage);
 
     if (this.isActive()) {
-      this.ws?.close();
+      this.ws.close();
       this.connectionProps.onDisconnect?.();
     }
 
@@ -106,7 +106,7 @@ export class WebSocketConnection<
       const packet = item.getPacket();
       const inworldPacket = this.convertPacketFromProto(item.getPacket());
       item.beforeWriting?.(inworldPacket);
-      this.ws?.send(JSON.stringify(packet));
+      this.ws.send(JSON.stringify(packet));
       item.afterWriting?.(inworldPacket);
     } else {
       this.packetQueue.push(item);

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -111,19 +111,19 @@ export interface NarratedAction {
 export class InworldPacket {
   private type: InworldPacketType = InworldPacketType.UNKNOWN;
 
-  date: string;
-  packetId: PacketId;
-  routing: Routing;
+  readonly date: string;
+  readonly packetId: PacketId;
+  readonly routing: Routing;
 
   // Events
-  text: TextEvent;
-  audio: AudioEvent;
-  trigger: TriggerEvent;
-  control: ControlEvent;
-  emotions: EmotionEvent;
-  silence: SilenceEvent;
-  narratedAction: NarratedAction;
-  cancelResponses: CancelResponsesEvent;
+  readonly text: TextEvent;
+  readonly audio: AudioEvent;
+  readonly trigger: TriggerEvent;
+  readonly control: ControlEvent;
+  readonly emotions: EmotionEvent;
+  readonly silence: SilenceEvent;
+  readonly narratedAction: NarratedAction;
+  readonly cancelResponses: CancelResponsesEvent;
 
   constructor(props: InworldPacketProps) {
     this.packetId = props.packetId;

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -1,3 +1,10 @@
+import {
+  ActorType,
+  AdditionalPhonemeInfo as ProtoAdditionalPhonemeInfo,
+  ControlEventAction,
+  DataChunkDataType,
+  InworldPacket as ProtoPacket,
+} from '../../proto/packets.pb';
 import { EmotionBehavior } from './emotion-behavior.entity';
 import { EmotionStrength } from './emotion-strength.entity';
 
@@ -222,5 +229,139 @@ export class InworldPacket {
 
   isNarratedAction() {
     return this.type === InworldPacketType.NARRATED_ACTION;
+  }
+
+  static fromProto(proto: ProtoPacket): InworldPacket {
+    const packetId = proto.packetId;
+    const routing = proto.routing;
+    const source = routing.source;
+    const target = routing.target;
+    const type = this.getType(proto);
+    const additionalPhonemeInfo = proto.dataChunk?.additionalPhonemeInfo ?? [];
+
+    return new InworldPacket({
+      type,
+      date: proto.timestamp,
+      packetId: {
+        packetId: packetId.packetId,
+        utteranceId: packetId.utteranceId,
+        interactionId: packetId.interactionId,
+      },
+      routing: {
+        source: {
+          name: source.name,
+          isPlayer: source.type === ActorType.PLAYER,
+          isCharacter: source.type === ActorType.AGENT,
+        },
+        target: {
+          name: target.name,
+          isPlayer: target.type === ActorType.PLAYER,
+          isCharacter: target.type === ActorType.AGENT,
+        },
+      },
+      ...(type === InworldPacketType.TRIGGER && {
+        trigger: {
+          name: proto.custom.name,
+          parameters: proto.custom.parameters?.map((p) => ({
+            name: p.name,
+            value: p.value,
+          })),
+        },
+      }),
+      ...(type === InworldPacketType.TEXT && {
+        text: {
+          text: proto.text.text,
+          final: proto.text.final,
+        },
+      }),
+      ...(type === InworldPacketType.AUDIO && {
+        audio: {
+          chunk: proto.dataChunk.chunk as unknown as string,
+          additionalPhonemeInfo: additionalPhonemeInfo.map(
+            (info: ProtoAdditionalPhonemeInfo) =>
+              ({
+                phoneme: info.phoneme,
+                startOffsetS: parseFloat(info.startOffset),
+              } as AdditionalPhonemeInfo),
+          ),
+        },
+      }),
+      ...(type === InworldPacketType.CONTROL && {
+        control: {
+          type: this.getControlType(proto),
+        },
+      }),
+      ...(type === InworldPacketType.SILENCE && {
+        silence: {
+          durationMs: parseInt(proto.dataChunk.durationMs, 10),
+        },
+      }),
+      ...(type === InworldPacketType.EMOTION && {
+        emotions: {
+          behavior: new EmotionBehavior(
+            EmotionBehavior.fromProto(proto.emotion.behavior),
+          ),
+          strength: new EmotionStrength(
+            EmotionStrength.fromProto(proto.emotion.strength),
+          ),
+        },
+      }),
+      ...(type === InworldPacketType.CANCEL_RESPONSE && {
+        cancelResponses: {
+          interactionId: proto.cancelResponses.interactionId,
+          utteranceId: proto.cancelResponses.utteranceId,
+        },
+      }),
+      ...(type === InworldPacketType.NARRATED_ACTION && {
+        narratedAction: {
+          text: proto.action.narratedAction.content,
+        },
+      }),
+    });
+  }
+
+  private static getType(packet: ProtoPacket) {
+    if (packet.text) {
+      return InworldPacketType.TEXT;
+    } else if (
+      packet.dataChunk &&
+      packet.dataChunk.type === DataChunkDataType.AUDIO
+    ) {
+      return InworldPacketType.AUDIO;
+    } else if (
+      packet.dataChunk &&
+      packet.dataChunk.type === DataChunkDataType.SILENCE
+    ) {
+      return InworldPacketType.SILENCE;
+    } else if (packet.custom) {
+      return InworldPacketType.TRIGGER;
+    } else if (packet.control) {
+      return InworldPacketType.CONTROL;
+    } else if (packet.emotion) {
+      return InworldPacketType.EMOTION;
+    } else if (packet.cancelResponses) {
+      return InworldPacketType.CANCEL_RESPONSE;
+    } else if (packet.action?.narratedAction) {
+      return InworldPacketType.NARRATED_ACTION;
+    } else {
+      return InworldPacketType.UNKNOWN;
+    }
+  }
+
+  private static getControlType(packet: ProtoPacket) {
+    switch (packet.control.action) {
+      case ControlEventAction.INTERACTION_END:
+        return InworlControlType.INTERACTION_END;
+      case ControlEventAction.TTS_PLAYBACK_START:
+        return InworlControlType.TTS_PLAYBACK_START;
+      case ControlEventAction.TTS_PLAYBACK_END:
+        return InworlControlType.TTS_PLAYBACK_END;
+      case ControlEventAction.TTS_PLAYBACK_MUTE:
+        return InworlControlType.TTS_PLAYBACK_MUTE;
+      case ControlEventAction.TTS_PLAYBACK_UNMUTE:
+        return InworlControlType.TTS_PLAYBACK_UNMUTE;
+      default:
+        return InworlControlType.UNKNOWN;
+    }
   }
 }

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -2,7 +2,6 @@ import { v4 } from 'uuid';
 
 import {
   ActorType,
-  AdditionalPhonemeInfo as ProtoAdditionalPhonemeInfo,
   ControlEventAction,
   DataChunkDataType,
   InworldPacket as ProtoPacket,
@@ -12,15 +11,7 @@ import {
 import { protoTimestamp } from '../common/helpers';
 import { CancelResponsesProps } from '../common/interfaces';
 import { Character } from '../entities/character.entity';
-import { EmotionBehavior } from '../entities/emotion-behavior.entity';
-import { EmotionStrength } from '../entities/emotion-strength.entity';
-import {
-  AdditionalPhonemeInfo,
-  InworlControlType,
-  InworldPacket,
-  InworldPacketType,
-  TriggerParameter,
-} from '../entities/inworld_packet.entity';
+import { TriggerParameter } from '../entities/inworld_packet.entity';
 
 export class EventFactory {
   private character: Character = null;
@@ -147,144 +138,10 @@ export class EventFactory {
     };
   }
 
-  static fromProto(proto: ProtoPacket): InworldPacket {
-    const packetId = proto.packetId;
-    const routing = proto.routing;
-    const source = routing.source;
-    const target = routing.target;
-    const type = this.getType(proto);
-    const additionalPhonemeInfo = proto.dataChunk?.additionalPhonemeInfo ?? [];
-
-    return new InworldPacket({
-      type,
-      date: proto.timestamp,
-      packetId: {
-        packetId: packetId.packetId,
-        utteranceId: packetId.utteranceId,
-        interactionId: packetId.interactionId,
-      },
-      routing: {
-        source: {
-          name: source.name,
-          isPlayer: source.type === ActorType.PLAYER,
-          isCharacter: source.type === ActorType.AGENT,
-        },
-        target: {
-          name: target.name,
-          isPlayer: target.type === ActorType.PLAYER,
-          isCharacter: target.type === ActorType.AGENT,
-        },
-      },
-      ...(type === InworldPacketType.TRIGGER && {
-        trigger: {
-          name: proto.custom.name,
-          parameters: proto.custom.parameters?.map((p) => ({
-            name: p.name,
-            value: p.value,
-          })),
-        },
-      }),
-      ...(type === InworldPacketType.TEXT && {
-        text: {
-          text: proto.text.text,
-          final: proto.text.final,
-        },
-      }),
-      ...(type === InworldPacketType.AUDIO && {
-        audio: {
-          chunk: proto.dataChunk.chunk as unknown as string,
-          additionalPhonemeInfo: additionalPhonemeInfo.map(
-            (info: ProtoAdditionalPhonemeInfo) =>
-              ({
-                phoneme: info.phoneme,
-                startOffsetS: parseFloat(info.startOffset),
-              } as AdditionalPhonemeInfo),
-          ),
-        },
-      }),
-      ...(type === InworldPacketType.CONTROL && {
-        control: {
-          type: this.getControlType(proto),
-        },
-      }),
-      ...(type === InworldPacketType.SILENCE && {
-        silence: {
-          durationMs: parseInt(proto.dataChunk.durationMs, 10),
-        },
-      }),
-      ...(type === InworldPacketType.EMOTION && {
-        emotions: {
-          behavior: new EmotionBehavior(
-            EmotionBehavior.fromProto(proto.emotion.behavior),
-          ),
-          strength: new EmotionStrength(
-            EmotionStrength.fromProto(proto.emotion.strength),
-          ),
-        },
-      }),
-      ...(type === InworldPacketType.CANCEL_RESPONSE && {
-        cancelResponses: {
-          interactionId: proto.cancelResponses.interactionId,
-          utteranceId: proto.cancelResponses.utteranceId,
-        },
-      }),
-      ...(type === InworldPacketType.NARRATED_ACTION && {
-        narratedAction: {
-          text: proto.action.narratedAction.content,
-        },
-      }),
-    });
-  }
-
   private routing(): Routing {
     return {
       source: { type: ActorType.PLAYER },
       target: { type: ActorType.AGENT, name: this.character?.id },
     };
-  }
-
-  private static getType(packet: ProtoPacket) {
-    if (packet.text) {
-      return InworldPacketType.TEXT;
-    } else if (
-      packet.dataChunk &&
-      packet.dataChunk.type === DataChunkDataType.AUDIO
-    ) {
-      return InworldPacketType.AUDIO;
-    } else if (
-      packet.dataChunk &&
-      packet.dataChunk.type === DataChunkDataType.SILENCE
-    ) {
-      return InworldPacketType.SILENCE;
-    } else if (packet.custom) {
-      return InworldPacketType.TRIGGER;
-    } else if (packet.control) {
-      return InworldPacketType.CONTROL;
-    } else if (packet.emotion) {
-      return InworldPacketType.EMOTION;
-    } else if (packet.cancelResponses) {
-      return InworldPacketType.CANCEL_RESPONSE;
-    } else if (packet.action?.narratedAction) {
-      return InworldPacketType.NARRATED_ACTION;
-    } else {
-      return InworldPacketType.UNKNOWN;
-    }
-  }
-
-  private static getControlType(packet: ProtoPacket) {
-    switch (packet.control.action) {
-      case ControlEventAction.INTERACTION_END:
-        return InworlControlType.INTERACTION_END;
-      case ControlEventAction.TTS_PLAYBACK_START:
-        return InworlControlType.TTS_PLAYBACK_START;
-      case ControlEventAction.TTS_PLAYBACK_END:
-        return InworlControlType.TTS_PLAYBACK_END;
-      case ControlEventAction.TTS_PLAYBACK_MUTE:
-        return InworlControlType.TTS_PLAYBACK_MUTE;
-      case ControlEventAction.TTS_PLAYBACK_UNMUTE:
-        return InworlControlType.TTS_PLAYBACK_UNMUTE;
-      default:
-        return InworlControlType.UNKNOWN;
-    }
   }
 }

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -8,8 +8,8 @@ import {
   Routing,
   TextEventSourceType,
 } from '../../proto/packets.pb';
+import { CancelResponsesProps } from '../common/data_structures';
 import { protoTimestamp } from '../common/helpers';
-import { CancelResponsesProps } from '../common/interfaces';
 import { Character } from '../entities/character.entity';
 import { TriggerParameter } from '../entities/inworld_packet.entity';
 
@@ -26,66 +26,42 @@ export class EventFactory {
 
   dataChunk(chunk: string, type: DataChunkDataType): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       dataChunk: { chunk: chunk as unknown as Uint8Array, type },
     };
   }
 
   audioSessionStart(): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       control: { action: ControlEventAction.AUDIO_SESSION_START },
     };
   }
 
   audioSessionEnd(): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       control: { action: ControlEventAction.AUDIO_SESSION_END },
     };
   }
 
   ttsPlaybackStart(): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       control: { action: ControlEventAction.TTS_PLAYBACK_START },
     };
   }
 
   ttsPlaybackEnd(): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       control: { action: ControlEventAction.TTS_PLAYBACK_END },
     };
   }
 
   ttsPlaybackMute(isMuted: boolean): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
       control: {
         action: isMuted
           ? ControlEventAction.TTS_PLAYBACK_MUTE
@@ -96,13 +72,7 @@ export class EventFactory {
 
   text(text: string): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-        utteranceId: v4(),
-        interactionId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket(),
       text: {
         sourceType: TextEventSourceType.TYPED_IN,
         text,
@@ -113,13 +83,7 @@ export class EventFactory {
 
   trigger(name: string, parameters: TriggerParameter[] = []): ProtoPacket {
     return {
-      packetId: {
-        packetId: v4(),
-        utteranceId: v4(),
-        interactionId: v4(),
-      },
-      timestamp: protoTimestamp(),
-      routing: this.routing(),
+      ...this.baseProtoPacket(),
       custom: {
         name,
         ...(parameters.length && { parameters }),
@@ -129,12 +93,20 @@ export class EventFactory {
 
   cancelResponse(cancelResponses?: CancelResponsesProps): ProtoPacket {
     return {
+      ...this.baseProtoPacket({ utteranceId: false, interactionId: false }),
+      cancelResponses,
+    };
+  }
+
+  baseProtoPacket(props?: { utteranceId?: boolean; interactionId?: boolean }) {
+    return {
       packetId: {
         packetId: v4(),
+        ...((props?.utteranceId ?? true) && { utteranceId: v4() }),
+        ...((props?.interactionId ?? true) && { interactionId: v4() }),
       },
       timestamp: protoTimestamp(),
       routing: this.routing(),
-      cancelResponses,
     };
   }
 

--- a/src/factories/event.ts
+++ b/src/factories/event.ts
@@ -9,6 +9,7 @@ import {
   Routing,
   TextEventSourceType,
 } from '../../proto/packets.pb';
+import { protoTimestamp } from '../common/helpers';
 import { CancelResponsesProps } from '../common/interfaces';
 import { Character } from '../entities/character.entity';
 import { EmotionBehavior } from '../entities/emotion-behavior.entity';
@@ -37,7 +38,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       dataChunk: { chunk: chunk as unknown as Uint8Array, type },
     };
@@ -48,7 +49,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       control: { action: ControlEventAction.AUDIO_SESSION_START },
     };
@@ -59,7 +60,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       control: { action: ControlEventAction.AUDIO_SESSION_END },
     };
@@ -70,7 +71,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       control: { action: ControlEventAction.TTS_PLAYBACK_START },
     };
@@ -81,7 +82,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       control: { action: ControlEventAction.TTS_PLAYBACK_END },
     };
@@ -92,7 +93,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       control: {
         action: isMuted
@@ -109,7 +110,7 @@ export class EventFactory {
         utteranceId: v4(),
         interactionId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       text: {
         sourceType: TextEventSourceType.TYPED_IN,
@@ -126,7 +127,7 @@ export class EventFactory {
         utteranceId: v4(),
         interactionId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       custom: {
         name,
@@ -140,7 +141,7 @@ export class EventFactory {
       packetId: {
         packetId: v4(),
       },
-      timestamp: this.protoTimestampNow(),
+      timestamp: protoTimestamp(),
       routing: this.routing(),
       cancelResponses,
     };
@@ -241,8 +242,6 @@ export class EventFactory {
       target: { type: ActorType.AGENT, name: this.character?.id },
     };
   }
-
-  private protoTimestampNow = () => new Date().toISOString();
 
   private static getType(packet: ProtoPacket) {
     if (packet.text) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   ClientConfiguration,
   ConnectionConfig,
   Extension,
+  ExtensionLoadSceneProps,
   SessionToken,
   User,
 } from './common/data_structures';
@@ -64,6 +65,7 @@ export {
   EmotionStrength,
   EmotionStrengthCode,
   Extension,
+  ExtensionLoadSceneProps,
   HistoryInteractionEnd,
   HistoryItem,
   HistoryItemActor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,16 @@
  * that can be found in the LICENSE.md file or at https://www.inworld.ai/sdk-license
  */
 
+import { InworldPacket as ProtoPacket } from '../proto/packets.pb';
 import { InworldClient } from './clients/inworld.client';
 import {
   Capabilities,
   ClientConfiguration,
   ConnectionConfig,
+  Extension,
   SessionToken,
   User,
-} from './common/interfaces';
+} from './common/data_structures';
 import {
   CHAT_HISTORY_TYPE,
   HistoryInteractionEnd,
@@ -61,6 +63,7 @@ export {
   EmotionEvent,
   EmotionStrength,
   EmotionStrengthCode,
+  Extension,
   HistoryInteractionEnd,
   HistoryItem,
   HistoryItemActor,
@@ -71,6 +74,7 @@ export {
   InworldConnectionService,
   InworldPacket,
   PacketId,
+  ProtoPacket,
   Routing,
   SessionToken,
   TextEvent,

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -84,13 +84,9 @@ export class ConnectionService<
   constructor(props?: ConnectionProps<InworldPacketT>) {
     this.connectionProps = props || ({} as ConnectionProps<InworldPacketT>);
 
-    this.extension = this.connectionProps.extension ?? {
-      convertPacketFromProto: (proto: ProtoPacket) =>
-        InworldPacket.fromProto(proto) as InworldPacketT,
-    };
-
     this.initializeHandlers();
     this.initializeConnection();
+    this.initializeExtension();
   }
 
   isActive() {
@@ -300,6 +296,7 @@ export class ConnectionService<
         this.scene = await engineService.loadScene({
           config: this.connectionProps.config,
           session: this.session,
+          sceneProps: this.extension.loadSceneProps,
           name,
           user,
           client,
@@ -441,6 +438,16 @@ export class ConnectionService<
     };
 
     this.connection = new WebSocketConnection(props);
+  }
+
+  private initializeExtension() {
+    const extension = this.connectionProps.extension ?? {};
+
+    this.extension = {
+      convertPacketFromProto: (proto: ProtoPacket) =>
+        InworldPacket.fromProto(proto) as InworldPacketT,
+      ...extension,
+    };
   }
 
   private interruptByInteraction(interactionId: string) {

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -238,7 +238,7 @@ export class ConnectionService {
     this.connection.write({
       getPacket,
       afterWriting: (packet: ProtoPacket) => {
-        inworldPacket = EventFactory.fromProto(packet);
+        inworldPacket = InworldPacket.fromProto(packet);
 
         this.scheduleDisconnect();
 
@@ -354,7 +354,7 @@ export class ConnectionService {
     this.onMessage = async (packet: ProtoPacket) => {
       const { onMessage, grpcAudioPlayer } = this.connectionProps;
 
-      const inworldPacket = EventFactory.fromProto(packet);
+      const inworldPacket = InworldPacket.fromProto(packet);
       const interactionId = inworldPacket.packetId.interactionId;
 
       // Don't pass text packet outside for interrupred interaction.

--- a/src/services/world_engine.service.ts
+++ b/src/services/world_engine.service.ts
@@ -8,7 +8,7 @@ import { CLIENT_ID } from '../common/constants';
 import {
   InternalClientConfiguration,
   SessionToken,
-} from '../common/interfaces';
+} from '../common/data_structures';
 
 type PbFunc<P, R> = (req: P, initReq?: fm.InitReq) => Promise<R>;
 

--- a/src/services/world_engine.service.ts
+++ b/src/services/world_engine.service.ts
@@ -6,6 +6,7 @@ import {
 } from '../../proto/world-engine.pb';
 import { CLIENT_ID } from '../common/constants';
 import {
+  ExtensionLoadSceneProps,
   InternalClientConfiguration,
   SessionToken,
 } from '../common/data_structures';
@@ -18,11 +19,12 @@ export interface LoadSceneProps {
   user?: UserRequest;
   config: InternalClientConfiguration;
   session: SessionToken;
+  sceneProps?: ExtensionLoadSceneProps;
 }
 
 export class WorldEngineService {
   async loadScene(props: LoadSceneProps) {
-    const { client, config, name, session, user } = props;
+    const { client, config, name, sceneProps, session, user } = props;
     const { hostname, ssl } = config.connection.gateway;
 
     const url = `${ssl ? 'https' : 'http'}://${hostname}`;
@@ -35,6 +37,7 @@ export class WorldEngineService {
       name,
       user,
       capabilities: config.capabilities,
+      ...sceneProps,
     });
   }
 


### PR DESCRIPTION
If you need to extend Inworld packet:

```
interface ExtendedCapabilities extends Capabilities {
  newCapability: boolean;
}

interface NewEvent {
  property?: string;
};

interface ExtendedInworldPacket extends InworldPacket {
  newEvent: NewEvent;
}

const client = new InworldClient<
  ExtendedCapabilities,
  ExtendedInworldPacket
>()
  ...
  .setConfiguration({
    capabilities: { audio: true, newCapability: true }
  })
  .setExtension({
    convertPacketFromProto: (proto: ProtoPacket) => {
      const packet = InworldPacket.fromProto(
        proto,
      ) as ExtendedInworldPacket;

      packet.newEvent = {
        property: v4(),
      };

      return packet;
    },
    // Any props except props that can be set using DSL (i.e. we exclude user/client/capabilities/name)
    loadSceneProps: {}
  });
```

If you don't need to extend Inworld packet do nothing additionally:

```
const client = new InworldClient()
  ...
  .setConfiguration({
    capabilities: { audio: true }
  });
```