### PR TITLE
Fix interruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 * Replace CancelResponses by Mutation.CancelResponses on the protocol level
 * Send TextEvent before CancelResponses on text interruption
+* Continue audio playing after interruption in Safari
 
 ## 2022-05-01 v1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Replace CancelResponses by Mutation.CancelResponses on the protocol level
+* Send TextEvent before CancelResponses on text interruption
 
 ## 2022-05-01 v1.1.0
 

--- a/__tests__/connection/web-socket.connection.spec.ts
+++ b/__tests__/connection/web-socket.connection.spec.ts
@@ -3,13 +3,16 @@ import { v4 } from 'uuid';
 
 import { InworldPacket as ProtoPacket } from '../../proto/packets.pb';
 import { WebSocketConnection } from '../../src/connection/web-socket.connection';
+import { EventFactory } from '../../src/factories/event';
 import { capabilitiesProps, session } from '../helpers';
+
+const eventFactory = new EventFactory();
 
 let server: WS;
 let ws: WebSocketConnection;
 
 const HOSTNAME = 'localhost:1234';
-const textMessage = { text: { text: v4() } };
+const textMessage = eventFactory.text(v4());
 
 const onReady = jest.fn();
 const onError = jest.fn();

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -10,6 +10,7 @@ import {
 import { QueueItem } from '../src/connection/web-socket.connection';
 import { Character } from '../src/entities/character.entity';
 import { PacketId } from '../src/entities/inworld_packet.entity';
+import { EventFactory } from '../src/factories/event';
 
 const today = new Date();
 today.setHours(today.getHours() + 1);
@@ -81,7 +82,9 @@ export const client: Client = {
 };
 
 export const writeMock = (item: QueueItem) => {
-  item.afterWriting?.(item.getPacket());
+  const packet = EventFactory.fromProto(item.getPacket());
+  item.beforeWriting?.(packet);
+  item.afterWriting?.(packet);
 };
 
 export const getPacketId = (): PacketId => ({

--- a/src/components/sound/grpc_audio.playback.ts
+++ b/src/components/sound/grpc_audio.playback.ts
@@ -134,13 +134,36 @@ export class GrpcAudioPlayback {
   }
 
   stop() {
-    this.getSourceNode().disconnect();
-    delete this.audioBufferSourceNode;
+    if (this.audioBufferSourceNode) {
+      this.audioBufferSourceNode.onended = null;
+    }
+
+    this.currentItem = undefined;
+    this.clearSourceNode();
+  }
+
+  stopForInteraction(interactionId: string) {
+    const packets = this.excludeCurrentInteractionPackets(interactionId);
+
+    if (!this.isCurrentPacket({ interactionId })) {
+      this.stop();
+      this.playQueue();
+    }
+
+    return packets;
   }
 
   async init() {
     // Way past safari autoplay. Should be called from inside direct user interaction.
     await this.playbackAudioContext.resume().catch(console.error);
+  }
+
+  private clearSourceNode() {
+    if (this.audioBufferSourceNode) {
+      this.audioBufferSourceNode.disconnect();
+    }
+
+    delete this.audioBufferSourceNode;
   }
 
   private getSourceNode(): AudioBufferSourceNode {
@@ -187,7 +210,7 @@ export class GrpcAudioPlayback {
       );
     }
 
-    this.stop();
+    this.clearSourceNode();
 
     this.getSourceNode().buffer = audioBuffer;
     if (packet.isAudio() && packet.audio.additionalPhonemeInfo) {

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -5,6 +5,8 @@ import {
   SessionToken,
   VoidFn,
 } from '../common/interfaces';
+import { InworldPacket } from '../entities/inworld_packet.entity';
+import { EventFactory } from '../factories/event';
 
 const SESSION_PATH = '/v1/session/default';
 
@@ -31,7 +33,8 @@ interface OpenConnectionProps {
 
 export interface QueueItem {
   getPacket: () => ProtoPacket;
-  afterWriting?: (packet: ProtoPacket) => void;
+  afterWriting?: (packet: InworldPacket) => void;
+  beforeWriting?: (packet: InworldPacket) => void;
 }
 
 export interface Connection {
@@ -97,8 +100,10 @@ export class WebSocketConnection implements Connection {
     // So put packets to queue and send them `onReady` event.
     if (this.isActive()) {
       const packet = item.getPacket();
+      const inworldPacket = EventFactory.fromProto(item.getPacket());
+      item.beforeWriting?.(inworldPacket);
       this.ws?.send(JSON.stringify(packet));
-      item.afterWriting?.(packet);
+      item.afterWriting?.(inworldPacket);
     } else {
       this.packetQueue.push(item);
     }

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -439,12 +439,7 @@ export class ConnectionService {
 
     if (!config?.capabilities.interruptions) return;
 
-    const packets =
-      grpcAudioPlayer.excludeCurrentInteractionPackets(interactionId);
-
-    if (!grpcAudioPlayer.isCurrentPacket({ interactionId })) {
-      grpcAudioPlayer.stop();
-    }
+    const packets = grpcAudioPlayer.stopForInteraction(interactionId);
 
     if (packets.length) {
       const interactionId = packets[0].packetId.interactionId;

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -237,16 +237,17 @@ export class ConnectionService {
     // If the connection is not active, we need to add the packet to the queue first to guarantee the order of packets.
     this.connection.write({
       getPacket,
-      afterWriting: (packet: ProtoPacket) => {
-        inworldPacket = EventFactory.fromProto(packet);
+      afterWriting: (packet: InworldPacket) => {
+        inworldPacket = packet;
 
         this.scheduleDisconnect();
 
-        if (inworldPacket.isText()) {
-          this.interruptByInteraction(inworldPacket.packetId.interactionId);
-        }
-
         this.addPacketToHistory(inworldPacket);
+      },
+      beforeWriting: (packet: InworldPacket) => {
+        if (packet.isText()) {
+          this.interruptByInteraction(packet.packetId.interactionId);
+        }
       },
     });
 


### PR DESCRIPTION
* Send TextEvent before CancelResponses on text interruption
* Continue audio playing after interruption in Safari. Ended event is not triggered for audioBufferSourceNode in Safari after disconnect. And anyway it's not correct to call onEnded callback if track was stopped: onAfterPlaying should not be called in this case. That's why we need to remove this listener and make all required actions manually after stop