### PR TITLE
Release 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+
+- Ensure `beforeLoadScene` and `afterLoadScene` are present before call them
 ## [1.5.2] - 2023-08-29
 
 ### Added

--- a/__tests__/services/pb/world_engine.service.spec.ts
+++ b/__tests__/services/pb/world_engine.service.spec.ts
@@ -231,4 +231,21 @@ describe('load scene', () => {
     expect(extension.beforeLoadScene).toHaveBeenCalledTimes(1);
     expect(extension.afterLoadScene).toHaveBeenCalledTimes(1);
   });
+
+  test('should not throw error on empty extension', async () => {
+    await client.loadScene({
+      config: {
+        capabilities,
+        connection: {
+          gateway: { hostname: 'examples.com', ssl: true },
+        },
+      },
+      name: SCENE,
+      session,
+      extension: {},
+    });
+
+    expect(extension.beforeLoadScene).toHaveBeenCalledTimes(0);
+    expect(extension.afterLoadScene).toHaveBeenCalledTimes(0);
+  });
 });

--- a/examples/chat/src/app/connection.ts
+++ b/examples/chat/src/app/connection.ts
@@ -39,8 +39,7 @@ export class InworldService {
       .setOnMessage(props.onMessage)
       .setOnPhoneme(props.onPhoneme)
       .setOnHistoryChange(props.onHistoryChange)
-      .setOnDisconnect(props.onDisconnect)
-      .setExtension({});
+      .setOnDisconnect(props.onDisconnect);
 
     this.connection = client.build();
   }

--- a/src/services/pb/world_engine.service.ts
+++ b/src/services/pb/world_engine.service.ts
@@ -30,7 +30,7 @@ export interface LoadSceneProps<InworldPacketT> {
 export class WorldEngineService<InworldPacketT> extends PbService {
   async loadScene(props: LoadSceneProps<InworldPacketT>) {
     const req = this.buildRequest(props);
-    const finalReq = props.extension?.beforeLoadScene(req) ?? req;
+    const finalReq = props.extension?.beforeLoadScene?.(req) ?? req;
 
     const res = await this.request(
       props.config,
@@ -39,7 +39,7 @@ export class WorldEngineService<InworldPacketT> extends PbService {
       finalReq,
     );
 
-    props.extension?.afterLoadScene(res);
+    props.extension?.afterLoadScene?.(res);
 
     return res;
   }


### PR DESCRIPTION
- Ensure `beforeLoadScene` and `afterLoadScene` are present before call them