### PR TITLE
fix: Fix auto release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Bump version
         run: |
           yarn release:bump ${{ inputs.increment }} --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
         run: yarn release:publish
         env:


### PR DESCRIPTION
## Description

Revert back `GITHUB_TOKEN` for `release:bump` command. Release is created automatically with this env variable

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code