### PR TITLE
Generate proto packet just once to dispatching it to the WebSocket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@
 
 - Remove excess extended capabilities generic type
 
+### Fixed
+
+- Generate proto packet just once to dispatching it to the WebSocket connection
+
 ## [1.5.3] - 2023-08-30
 
 ### Fixed
 
 - Ensure `beforeLoadScene` and `afterLoadScene` are present before call them
+
 ## [1.5.2] - 2023-08-29
 
 ### Added

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -104,7 +104,7 @@ export class WebSocketConnection<
     // So put packets to queue and send them `onReady` event.
     if (this.isActive()) {
       const packet = item.getPacket();
-      const inworldPacket = this.convertPacketFromProto(item.getPacket());
+      const inworldPacket = this.convertPacketFromProto(packet);
       await item.beforeWriting?.(inworldPacket);
       this.ws.send(JSON.stringify(packet));
       item.afterWriting?.(inworldPacket);


### PR DESCRIPTION
## Description

Fix "typo": proto packet should be generated once. And then to be converted to Inworld packet

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3622

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
