### PR TITLE
Include overlooked calls to the `historyItem` method for queued packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Include overlooked calls to the `historyItem` method for queued packets
+
 ## [1.6.0] - 2023-09-08
 
 ### Added


### PR DESCRIPTION
## Description

### Fixed

- Include overlooked calls to the `historyItem` method for queued packets

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3871

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
