### PR TITLE
Allow to use async `onDisconnect` and `onError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Allow to use async `onDisconnect` and `onError`
+
 ### Fixed
 
 - Include the correlationId in both the fromProto conversion method and the associated historical items

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -11,7 +11,6 @@ import {
   InternalClientConfiguration,
   OnPhomeneFn,
   User,
-  VoidFn,
 } from '../common/data_structures';
 import { HistoryItem } from '../components/history';
 import { GrpcAudioPlayback } from '../components/sound/grpc_audio.playback';
@@ -38,8 +37,8 @@ export class InworldClient<
 
   private generateSessionToken: GenerateSessionTokenFn;
 
-  private onDisconnect: VoidFn | undefined;
-  private onError: ((err: Event | Error) => void) | undefined;
+  private onDisconnect: () => Awaitable<void> | undefined;
+  private onError: ((err: Event | Error) => Awaitable<void>) | undefined;
   private onMessage: ((message: InworldPacketT) => Awaitable<void>) | undefined;
   private onReady: (() => Awaitable<void>) | undefined;
   private onHistoryChange:
@@ -89,13 +88,13 @@ export class InworldClient<
     return this;
   }
 
-  setOnDisconnect(fn?: VoidFn) {
+  setOnDisconnect(fn?: () => Awaitable<void>) {
     this.onDisconnect = fn;
 
     return this;
   }
 
-  setOnError(fn?: (err: Error) => void) {
+  setOnError(fn?: (err: Error) => Awaitable<void>) {
     this.onError = fn;
 
     return this;

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -85,7 +85,6 @@ export interface CancelResponsesProps {
 }
 
 export type Awaitable<T> = T | PromiseLike<T>;
-export type VoidFn = () => void;
 export type GenerateSessionTokenFn = () => Promise<SessionToken>;
 export type OnPhomeneFn =
   | ((phonemeData: AdditionalPhonemeInfo[]) => void)

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -3,7 +3,6 @@ import {
   Awaitable,
   InternalClientConfiguration,
   SessionToken,
-  VoidFn,
 } from '../common/data_structures';
 import { InworldPacket } from '../entities/inworld_packet.entity';
 
@@ -12,16 +11,16 @@ const SESSION_PATH = '/v1/session/default';
 interface SessionProps {
   config: InternalClientConfiguration;
   session: SessionToken;
-  onDisconnect?: VoidFn;
-  onError?: (err: Event | Error) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: ProtoPacket) => Awaitable<void>;
-  onReady?: VoidFn;
+  onReady?: () => Awaitable<void>;
 }
 interface ConnectionProps {
   config?: InternalClientConfiguration;
-  onDisconnect?: VoidFn;
+  onDisconnect?: () => Awaitable<void>;
   onReady?: () => Awaitable<void>;
-  onError?: (err: Event | Error) => void;
+  onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: ProtoPacket) => Awaitable<void>;
 }
 


### PR DESCRIPTION
## Description

We should have opportunity to use async callbacks when it's required

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3888

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
