### PR TITLE
fix: Include overlooked trigger parameters to corresponding history item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Include the correlationId in both the fromProto conversion method and the associated historical items
+- Include overlooked trigger parameters to corresponding history item
 
 ## [1.6.1] - 2023-09-13
 

--- a/__tests__/components/history.spec.ts
+++ b/__tests__/components/history.spec.ts
@@ -55,7 +55,7 @@ const triggerPacket = new InworldPacket({
   packetId,
   routing,
   date,
-  trigger: { name: v4() },
+  trigger: { name: v4(), parameters: [{ name: v4(), value: v4() }] },
   type: InworldPacketType.TRIGGER,
 });
 const narracterActionPacket = new InworldPacket({

--- a/src/components/history.ts
+++ b/src/components/history.ts
@@ -7,6 +7,7 @@ import {
   Actor,
   EmotionEvent,
   InworldPacket,
+  TriggerParameter,
 } from '../entities/inworld_packet.entity';
 import { GrpcAudioPlayback } from './sound/grpc_audio.playback';
 
@@ -44,6 +45,7 @@ export interface HistoryItemActor extends HistoryItemBase {
 export interface HistoryItemTriggerEvent extends HistoryItemBase {
   type: CHAT_HISTORY_TYPE.TRIGGER_EVENT;
   name: string;
+  parameters: TriggerParameter[];
   outgoing?: boolean;
   correlationId?: string;
 }
@@ -359,6 +361,7 @@ export class InworldHistory<
       type: CHAT_HISTORY_TYPE.TRIGGER_EVENT,
       name: packet.trigger.name,
       correlationId,
+      parameters: packet.trigger.parameters,
       date,
       interactionId,
       outgoing,


### PR DESCRIPTION
## Description

Trigger parameter should be available in history item

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-3947

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
