### PR TITLE
Release 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Allow to use async `onDisconnect` and `onError`
+
 ### Fixed
 
 - Include the correlationId in both the fromProto conversion method and the associated historical items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Include the correlationId in both the fromProto conversion method and the associated historical items
+- Include overlooked trigger parameters to corresponding history item
 
 ## [1.6.1] - 2023-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Include the correlationId in both the fromProto conversion method and the associated historical items
+
 ## [1.6.1] - 2023-09-13
 
 ### Fixed

--- a/__tests__/components/history.spec.ts
+++ b/__tests__/components/history.spec.ts
@@ -55,7 +55,7 @@ const triggerPacket = new InworldPacket({
   packetId,
   routing,
   date,
-  trigger: { name: v4() },
+  trigger: { name: v4(), parameters: [{ name: v4(), value: v4() }] },
   type: InworldPacketType.TRIGGER,
 });
 const narracterActionPacket = new InworldPacket({

--- a/__tests__/entities/inworld_packet.entity.spec.ts
+++ b/__tests__/entities/inworld_packet.entity.spec.ts
@@ -12,6 +12,10 @@ import {
 import { getPacketId } from '../helpers';
 
 const packetId = getPacketId();
+const packetIdWithCorrelation = {
+  ...packetId,
+  correlationId: v4(),
+};
 const routing: Routing = {
   source: {
     name: v4(),
@@ -54,7 +58,7 @@ test('should get text packet fields', () => {
 
   const packet = new InworldPacket({
     text,
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TEXT,
@@ -64,12 +68,12 @@ test('should get text packet fields', () => {
   expect(packet.text).toEqual(text);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get trigger packet fields', () => {
   const packet = new InworldPacket({
-    packetId,
+    packetId: packetIdWithCorrelation,
     routing,
     date,
     type: InworldPacketType.TRIGGER,
@@ -78,7 +82,7 @@ test('should get trigger packet fields', () => {
   expect(packet.isTrigger()).toEqual(true);
   expect(packet.routing).toEqual(routing);
   expect(packet.date).toEqual(date);
-  expect(packet.packetId).toEqual(packetId);
+  expect(packet.packetId).toEqual(packetIdWithCorrelation);
 });
 
 test('should get emotion packet fields', () => {

--- a/__tests__/services/connection.service.spec.ts
+++ b/__tests__/services/connection.service.spec.ts
@@ -438,6 +438,7 @@ describe('send', () => {
           {
             id: textEvent.packetId.utteranceId,
             character: undefined,
+            correlationId: textEvent.packetId.correlationId,
             date: new Date(textEvent.timestamp),
             interactionId: textEvent.packetId.interactionId,
             isRecognizing: false,

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -11,7 +11,6 @@ import {
   InternalClientConfiguration,
   OnPhomeneFn,
   User,
-  VoidFn,
 } from '../common/data_structures';
 import { HistoryItem } from '../components/history';
 import { GrpcAudioPlayback } from '../components/sound/grpc_audio.playback';
@@ -38,8 +37,8 @@ export class InworldClient<
 
   private generateSessionToken: GenerateSessionTokenFn;
 
-  private onDisconnect: VoidFn | undefined;
-  private onError: ((err: Event | Error) => void) | undefined;
+  private onDisconnect: () => Awaitable<void> | undefined;
+  private onError: ((err: Event | Error) => Awaitable<void>) | undefined;
   private onMessage: ((message: InworldPacketT) => Awaitable<void>) | undefined;
   private onReady: (() => Awaitable<void>) | undefined;
   private onHistoryChange:
@@ -89,13 +88,13 @@ export class InworldClient<
     return this;
   }
 
-  setOnDisconnect(fn?: VoidFn) {
+  setOnDisconnect(fn?: () => Awaitable<void>) {
     this.onDisconnect = fn;
 
     return this;
   }
 
-  setOnError(fn?: (err: Error) => void) {
+  setOnError(fn?: (err: Error) => Awaitable<void>) {
     this.onError = fn;
 
     return this;

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -85,7 +85,6 @@ export interface CancelResponsesProps {
 }
 
 export type Awaitable<T> = T | PromiseLike<T>;
-export type VoidFn = () => void;
 export type GenerateSessionTokenFn = () => Promise<SessionToken>;
 export type OnPhomeneFn =
   | ((phonemeData: AdditionalPhonemeInfo[]) => void)

--- a/src/components/history.ts
+++ b/src/components/history.ts
@@ -7,6 +7,7 @@ import {
   Actor,
   EmotionEvent,
   InworldPacket,
+  TriggerParameter,
 } from '../entities/inworld_packet.entity';
 import { GrpcAudioPlayback } from './sound/grpc_audio.playback';
 
@@ -44,6 +45,7 @@ export interface HistoryItemActor extends HistoryItemBase {
 export interface HistoryItemTriggerEvent extends HistoryItemBase {
   type: CHAT_HISTORY_TYPE.TRIGGER_EVENT;
   name: string;
+  parameters: TriggerParameter[];
   outgoing?: boolean;
   correlationId?: string;
 }
@@ -359,6 +361,7 @@ export class InworldHistory<
       type: CHAT_HISTORY_TYPE.TRIGGER_EVENT,
       name: packet.trigger.name,
       correlationId,
+      parameters: packet.trigger.parameters,
       date,
       interactionId,
       outgoing,

--- a/src/components/history.ts
+++ b/src/components/history.ts
@@ -38,12 +38,14 @@ export interface HistoryItemActor extends HistoryItemBase {
   emotions?: EmotionEvent;
   isRecognizing?: boolean;
   character?: Character;
+  correlationId?: string;
 }
 
 export interface HistoryItemTriggerEvent extends HistoryItemBase {
   type: CHAT_HISTORY_TYPE.TRIGGER_EVENT;
   name: string;
   outgoing?: boolean;
+  correlationId?: string;
 }
 
 export interface HistoryInteractionEnd extends HistoryItemBase {
@@ -312,12 +314,14 @@ export class InworldHistory<
     const source = packet.routing?.source;
     const utteranceId = packet.packetId?.utteranceId;
     const interactionId = packet.packetId?.interactionId;
+    const correlationId = packet.packetId?.correlationId;
 
     return {
       id: utteranceId,
       isRecognizing: !packet.text.final,
       type: CHAT_HISTORY_TYPE.ACTOR,
       text: packet.text.text,
+      correlationId,
       date,
       interactionId,
       source,
@@ -348,11 +352,13 @@ export class InworldHistory<
     const source = packet.routing?.source;
     const utteranceId = packet.packetId?.utteranceId;
     const interactionId = packet.packetId?.interactionId;
+    const correlationId = packet.packetId?.correlationId;
 
     return {
       id: utteranceId,
       type: CHAT_HISTORY_TYPE.TRIGGER_EVENT,
       name: packet.trigger.name,
+      correlationId,
       date,
       interactionId,
       outgoing,

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -3,7 +3,6 @@ import {
   Awaitable,
   InternalClientConfiguration,
   SessionToken,
-  VoidFn,
 } from '../common/data_structures';
 import { InworldPacket } from '../entities/inworld_packet.entity';
 
@@ -12,16 +11,16 @@ const SESSION_PATH = '/v1/session/default';
 interface SessionProps {
   config: InternalClientConfiguration;
   session: SessionToken;
-  onDisconnect?: VoidFn;
-  onError?: (err: Event | Error) => void;
+  onDisconnect?: () => Awaitable<void>;
+  onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: ProtoPacket) => Awaitable<void>;
-  onReady?: VoidFn;
+  onReady?: () => Awaitable<void>;
 }
 interface ConnectionProps {
   config?: InternalClientConfiguration;
-  onDisconnect?: VoidFn;
+  onDisconnect?: () => Awaitable<void>;
   onReady?: () => Awaitable<void>;
-  onError?: (err: Event | Error) => void;
+  onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: ProtoPacket) => Awaitable<void>;
 }
 

--- a/src/entities/inworld_packet.entity.ts
+++ b/src/entities/inworld_packet.entity.ts
@@ -48,6 +48,7 @@ export interface PacketId {
   packetId: string;
   utteranceId: string;
   interactionId: string;
+  correlationId?: string;
 }
 
 export interface EmotionEvent {
@@ -249,6 +250,7 @@ export class InworldPacket {
         packetId: packetId.packetId,
         utteranceId: packetId.utteranceId,
         interactionId: packetId.interactionId,
+        correlationId: packetId.correlationId,
       },
       routing: {
         source: {


### PR DESCRIPTION
### Added

- Allow to use async `onDisconnect` and `onError`

### Fixed

- Include the correlationId in both the fromProto conversion method and the associated historical items
- Include overlooked trigger parameters to corresponding history item