### PR TITLE
fix: Send a `MUTE` event when auto-reconnecting prior to transmitting any other packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Send a `MUTE` event when auto-reconnecting prior to transmitting any other packets, provided that a `MUTE` event was sent prior to the disconnection
+
 ## [1.6.2] - 2023-09-20
 
 ### Added

--- a/__tests__/connection/web-socket.connection.spec.ts
+++ b/__tests__/connection/web-socket.connection.spec.ts
@@ -135,6 +135,31 @@ describe('open', () => {
 
     expect(onDisconnect).toHaveBeenCalledTimes(1);
   });
+
+  test('should send packet propagated to open call before sending other ones', async () => {
+    const ws = new WebSocketConnection({
+      config: {
+        connection: { gateway: { hostname: HOSTNAME } },
+        capabilities: capabilitiesProps,
+      },
+    });
+    const muteEvent = eventFactory.ttsPlaybackMute(true);
+
+    ws.open({
+      session,
+      convertPacketFromProto,
+      packets: [{ getPacket: () => muteEvent }],
+    });
+
+    ws.write({
+      getPacket: () => textMessage,
+    });
+
+    await server.connected;
+
+    await expect(server).toReceiveMessage(muteEvent);
+    await expect(server).toReceiveMessage(textMessage);
+  });
 });
 
 describe('write', () => {

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -104,6 +104,12 @@ export enum AudioSessionState {
   END = 'END',
 }
 
+export enum TtsPlaybackAction {
+  UNKNOWN = 'UNKNOWN',
+  MUTE = 'MUTE',
+  UNMUTE = 'UNMUTE',
+}
+
 export interface Extension<InworldPacketT, HistoryItemT> {
   convertPacketFromProto?: (proto: ProtoPacket) => InworldPacketT;
   beforeLoadScene?: (request: LoadSceneRequest) => LoadSceneRequest;

--- a/src/connection/web-socket.connection.ts
+++ b/src/connection/web-socket.connection.ts
@@ -27,6 +27,7 @@ interface ConnectionProps {
 interface OpenConnectionProps<InworldPacketT> {
   session: SessionToken;
   convertPacketFromProto: (proto: ProtoPacket) => InworldPacketT;
+  packets?: QueueItem<InworldPacketT>[];
 }
 
 export interface QueueItem<InworldPacketT> {
@@ -61,10 +62,15 @@ export class WebSocketConnection<
 
   async open({
     session,
+    packets,
     convertPacketFromProto,
   }: OpenConnectionProps<InworldPacketT>) {
     const { config, onError, onDisconnect, onMessage, onReady } =
       this.connectionProps;
+
+    if (packets?.length) {
+      this.packetQueue = [...packets, ...this.packetQueue];
+    }
 
     this.convertPacketFromProto = convertPacketFromProto;
     this.ws = this.createWebSocket({

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -11,6 +11,7 @@ import {
   GenerateSessionTokenFn,
   InternalClientConfiguration,
   SessionToken,
+  TtsPlaybackAction,
   User,
 } from '../common/data_structures';
 import {
@@ -23,6 +24,7 @@ import { GrpcWebRtcLoopbackBiDiSession } from '../components/sound/grpc_web_rtc_
 import { Player } from '../components/sound/player';
 import {
   Connection,
+  QueueItem,
   WebSocketConnection,
 } from '../connection/web-socket.connection';
 import { Character } from '../entities/character.entity';
@@ -57,6 +59,7 @@ export class ConnectionService<
   private player = Player.getInstance();
   private state: ConnectionState = ConnectionState.INACTIVE;
   private audioSessionAction = AudioSessionState.UNKNOWN;
+  private ttsPlaybackAction = TtsPlaybackAction.UNKNOWN;
 
   private scene: LoadSceneResponse;
   private session: SessionToken;
@@ -153,9 +156,12 @@ export class ConnectionService<
       if (this.state === ConnectionState.LOADED) {
         this.state = ConnectionState.ACTIVATING;
 
+        const packets = this.getPacketsToSentOnOpen();
+
         await this.connection.open({
           session: this.session,
           convertPacketFromProto: this.extension.convertPacketFromProto,
+          ...(packets.length && { packets }),
         });
 
         this.scheduleDisconnect();
@@ -185,6 +191,14 @@ export class ConnectionService<
 
   getAudioSessionAction() {
     return this.audioSessionAction;
+  }
+
+  setTtsPlaybackAction(action: TtsPlaybackAction) {
+    this.ttsPlaybackAction = action;
+  }
+
+  getTtsPlaybackAction() {
+    return this.ttsPlaybackAction;
   }
 
   async interrupt() {
@@ -533,5 +547,19 @@ export class ConnectionService<
     });
 
     this.intervals = [];
+  }
+
+  private getPacketsToSentOnOpen() {
+    const packets: QueueItem<InworldPacketT>[] = [];
+
+    if (this.isAutoReconnected()) {
+      if (this.getTtsPlaybackAction() === TtsPlaybackAction.MUTE) {
+        packets.push({
+          getPacket: () => this.getEventFactory().ttsPlaybackMute(true),
+        });
+      }
+    }
+
+    return packets;
   }
 }

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -5,6 +5,7 @@ import {
 import {
   AudioSessionState,
   CancelResponsesProps,
+  TtsPlaybackAction,
 } from '../common/data_structures';
 import { GrpcAudioPlayback } from '../components/sound/grpc_audio.playback';
 import { GrpcAudioRecorder } from '../components/sound/grpc_audio.recorder';
@@ -158,6 +159,10 @@ export class InworldConnectionService<
   }
 
   async sendTTSPlaybackMute(isMuted: boolean) {
+    this.connection.setTtsPlaybackAction(
+      isMuted ? TtsPlaybackAction.MUTE : TtsPlaybackAction.UNMUTE,
+    );
+
     return this.connection.send(() =>
       this.connection.getEventFactory().ttsPlaybackMute(isMuted),
     );


### PR DESCRIPTION
## Description

Send a `MUTE` event when auto-reconnecting prior to transmitting any other packets, provided that a `MUTE` event was sent prior to the disconnection

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4030

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
