### PR TITLE
Allow to add previous state packets to history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Allow to add previous state packets to history
+
 ### Fixed
 
 - Send a `MUTE` event when auto-reconnecting prior to transmitting any other packets, provided that a `MUTE` event was sent prior to the disconnection

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -34,6 +34,7 @@ describe('should finish with success', () => {
       .setConfiguration({
         capabilities: capabilitiesProps,
         audioPlayback: { stop: { duration: 1000, ticks: 30 } },
+        history: { previousState: true },
       })
       .setUser(user)
       .setClient(client)

--- a/src/common/data_structures.ts
+++ b/src/common/data_structures.ts
@@ -63,16 +63,22 @@ export interface ConnectionConfig {
   disconnectTimeout?: number;
   gateway?: Gateway;
 }
+
+export interface HistoryConfig {
+  previousState?: boolean;
+}
 export interface ClientConfiguration {
   connection?: ConnectionConfig;
   capabilities?: Capabilities;
   audioPlayback?: AudioPlaybackConfig;
+  history?: HistoryConfig;
 }
 
 export interface InternalClientConfiguration {
   connection?: ConnectionConfig;
   capabilities: CapabilitiesRequest;
   audioPlayback?: AudioPlaybackConfig;
+  history?: HistoryConfig;
 }
 
 export interface CancelResponses {


### PR DESCRIPTION
## Description

Allow to add packets to history SDK object using configuration

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4031

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
