### PR TITLE
Expose `interactionId` and `utteranceId` of interrupted packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Expose `interactionId` and `utteranceId` of interrupted packets
+
 ## [1.7.0] - 2023-09-27
 
 ### Added

--- a/__tests__/clients/inworld.client.spec.ts
+++ b/__tests__/clients/inworld.client.spec.ts
@@ -25,6 +25,7 @@ describe('should finish with success', () => {
   const onAfterPlaying = jest.fn();
   const onBeforePlaying = jest.fn();
   const onHistoryChange = jest.fn();
+  const onInterruption = jest.fn();
   const onPhoneme = jest.fn();
 
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('should finish with success', () => {
       .setOnError(onError)
       .setOnReady(onReady)
       .setOnHistoryChange(onHistoryChange)
+      .setOnInterruption(onInterruption)
       .setOnPhoneme(onPhoneme)
       .setSessionContinuation({ previousDialog: phrases });
   });

--- a/src/clients/inworld.client.ts
+++ b/src/clients/inworld.client.ts
@@ -1,3 +1,4 @@
+import { CancelResponses } from '../../proto/packets.pb';
 import { CapabilitiesRequest } from '../../proto/world-engine.pb';
 import { GRPC_HOSTNAME } from '../common/constants';
 import {
@@ -43,6 +44,9 @@ export class InworldClient<
   private onReady: (() => Awaitable<void>) | undefined;
   private onHistoryChange:
     | ((history: HistoryItem[]) => Awaitable<void>)
+    | undefined;
+  private onInterruption:
+    | ((props: CancelResponses) => Awaitable<void>)
     | undefined;
   private onPhoneme: OnPhomeneFn;
 
@@ -118,6 +122,12 @@ export class InworldClient<
     return this;
   }
 
+  setOnInterruption(fn?: (props: CancelResponses) => Awaitable<void>) {
+    this.onInterruption = fn;
+
+    return this;
+  }
+
   setOnPhoneme(fn?: OnPhomeneFn) {
     this.onPhoneme = fn;
 
@@ -181,6 +191,7 @@ export class InworldClient<
       onMessage: this.onMessage,
       onHistoryChange: this.onHistoryChange,
       onDisconnect: this.onDisconnect,
+      onInterruption: this.onInterruption,
       generateSessionToken: this.generateSessionToken,
       sessionContinuation: this.sessionContinuation,
       extension: this.extension,

--- a/src/services/connection.service.ts
+++ b/src/services/connection.service.ts
@@ -46,6 +46,7 @@ interface ConnectionProps<InworldPacketT, HistoryItemT> {
   onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: InworldPacketT) => Awaitable<void>;
   onDisconnect?: () => Awaitable<void>;
+  onInterruption?: (props: CancelResponsesProps) => Awaitable<void>;
   onHistoryChange?: (history: HistoryItem[]) => Awaitable<void>;
   grpcAudioPlayer: GrpcAudioPlayback;
   webRtcLoopbackBiDiSession: GrpcWebRtcLoopbackBiDiSession;
@@ -523,10 +524,14 @@ export class ConnectionService<
         [cancelReponses.interactionId]: true,
       };
 
-      this.history.filter({
+      const interruptionData = {
         utteranceId: cancelReponses.utteranceId ?? [],
         interactionId: cancelReponses.interactionId,
-      });
+      };
+
+      this.connectionProps.onInterruption?.(interruptionData);
+
+      this.history.filter(interruptionData);
     }
   }
 


### PR DESCRIPTION
## Description

Add `onInterruption` callback to DSL

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4083

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
