### PR TITLE
fix: Stop playing and recording sound on connection manual closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Stop playing and recording sound on connection manual closing
+
 ## [1.9.0] - 2023-10-04
 
 ### Added

--- a/__tests__/services/inworld_connection.service.spec.ts
+++ b/__tests__/services/inworld_connection.service.spec.ts
@@ -79,7 +79,7 @@ test('should return active state', () => {
   expect(service.isActive()).toEqual(true);
 });
 
-test('close', () => {
+test('close', async () => {
   const service = new InworldConnectionService({
     connection,
     grpcAudioPlayer,
@@ -89,9 +89,19 @@ test('close', () => {
   const close = jest
     .spyOn(connection, 'close')
     .mockImplementationOnce(jest.fn());
-  service.close();
+  const playerStop = jest
+    .spyOn(GrpcAudioPlayback.prototype, 'stop')
+    .mockImplementationOnce(jest.fn());
+
+  const recorderStop = jest
+    .spyOn(GrpcAudioRecorder.prototype, 'stopConvertion')
+    .mockImplementationOnce(jest.fn());
+
+  await service.close();
 
   expect(close).toHaveBeenCalledTimes(1);
+  expect(playerStop).toHaveBeenCalledTimes(1);
+  expect(recorderStop).toHaveBeenCalledTimes(1);
 });
 
 test('should get session state', async () => {

--- a/src/services/inworld_connection.service.ts
+++ b/src/services/inworld_connection.service.ts
@@ -70,8 +70,11 @@ export class InworldConnectionService<
     return this.connection.openManually();
   }
 
-  close() {
+  async close() {
     this.connection.close();
+    this.recorder.stop();
+    await this.player.stop();
+    this.player.clear();
   }
 
   isActive() {


### PR DESCRIPTION
## Description

It doesn't make a sense to call `player.stop` and `recorder.stop` manually

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4297

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
