### PR TITLE
fix: Set up environment variables for example package.json scripts in a cross-browser compatible manner

### DIFF
--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -21,11 +21,12 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@types/three": "^0.154.0",
+    "cross-env": "^7.0.3",
     "typescript": "^4.9.5"
   },
   "scripts": {
-    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
-    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build"
+    "start": "cross-env DISABLE_ESLINT_PLUGIN=true react-scripts start",
+    "build": "cross-env DISABLE_ESLINT_PLUGIN=true react-scripts build"
   },
   "browserslist": {
     "production": [

--- a/examples/chat/yarn.lock
+++ b/examples/chat/yarn.lock
@@ -3647,7 +3647,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==

--- a/examples/generate_token/package.json
+++ b/examples/generate_token/package.json
@@ -12,7 +12,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@inworld/nodejs-sdk": "1.6.0",
+    "@inworld/nodejs-sdk": "1.10.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1"

--- a/examples/generate_token/yarn.lock
+++ b/examples/generate_token/yarn.lock
@@ -42,10 +42,10 @@
     protobufjs "^7.2.4"
     yargs "^17.7.2"
 
-"@inworld/nodejs-sdk@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@inworld/nodejs-sdk/-/nodejs-sdk-1.6.0.tgz#a9332f3e4130ea1851cf0dad4089d5892a68840f"
-  integrity sha512-rDfQQrHlNKLQRTzr4yx9t5PmuG60K3klpS/JmqwfrZhtV3cRwhd/8fWR8XHC6J2kXUoVOqemTx10rvLoXGNqGQ==
+"@inworld/nodejs-sdk@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@inworld/nodejs-sdk/-/nodejs-sdk-1.10.0.tgz#844c9714b0f24a07a7bbe2647770be1321ece600"
+  integrity sha512-CsyQtURySrrcIAOpX9uaeoDCDjT7TvnCMoyJmOpFTtUzAnlc5M7SwcXmBsqS4e7HFQIiqmEY0dAUAQRLU7XMKw==
   dependencies:
     "@grpc/grpc-js" "^1.6.7"
     crypto-js "^4.1.1"


### PR DESCRIPTION
## Description

Need to have DISABLE_ESLINT_PLUGIN=true for chat example, but it didn't work on Windows


## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/CORE-4338

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
