### PR TITLE
Fix: WebSDK chat example. Bug with RPM Avatar default model naming target

### DIFF
--- a/examples/chat/bak.env copy.local
+++ b/examples/chat/bak.env copy.local
@@ -1,0 +1,11 @@
+# Innequin Local Developer
+# Base Asset File Location
+REACT_APP_ANIMATIONS_URI=./assets/models/animations/emotions/
+REACT_APP_IMAGES_FACIAL_URI=./assets/textures/face/emotions/
+REACT_APP_IMAGES_BODY_URI=./assets/textures/body/
+REACT_APP_MODEL_URI=./assets/innequin_v3.glb
+# Support Library Location
+REACT_APP_DRACO_COMPRESSION_URI=/draco-gltf/
+# Innequin Defaults
+REACT_APP_DEFAULT_ANIMATION=Neutral_Hello_Long_01
+REACT_APP_DEFAULT_SKIN=WOOD1

--- a/examples/chat/bak.env.development.v2
+++ b/examples/chat/bak.env.development.v2
@@ -1,0 +1,11 @@
+# Innequin V2 Env File Settings
+# Base Asset File Location
+REACT_APP_ANIMATIONS_URI=https://storage.googleapis.com/assets-inworld-ai/models/innequin/v2/models/animations/emotions/
+REACT_APP_IMAGES_FACIAL_URI=https://storage.googleapis.com/assets-inworld-ai/models/innequin/v2/textures/face/emotions/
+REACT_APP_IMAGES_BODY_URI=https://storage.googleapis.com/assets-inworld-ai/models/innequin/v2/textures/body/
+REACT_APP_MODEL_URI=https://storage.googleapis.com/assets-inworld-ai/models/innequin/v2/models/body/innequin.glb
+# Support Library Location
+REACT_APP_DRACO_COMPRESSION_URI=https://storage.googleapis.com/assets-inworld-ai/models/innequin/v2/draco-gltf/
+# Innequin Defaults
+REACT_APP_DEFAULT_ANIMATION=Neutral_Hello_Long_01
+REACT_APP_DEFAULT_SKIN=WOOD1

--- a/examples/chat/src/app/components/3dAvatar/Lipsync.tsx
+++ b/examples/chat/src/app/components/3dAvatar/Lipsync.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable */
 import { AdditionalPhonemeInfo } from '@inworld/web-sdk';
-import { useEffect, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
+import React, { useEffect, useState } from 'react';
+import { Group, Mesh, SkinnedMesh } from 'three';
+
 import { getVisemeData } from './PhonemDataToVisemeDataConverter';
-import { Group, SkinnedMesh } from 'three';
-import React from 'react';
 
 interface LipSyncProps {
   modelRef: React.MutableRefObject<Group>;
@@ -26,15 +26,22 @@ export function LipSync(props: LipSyncProps) {
   useEffect(() => {
     let modelData = props.modelRef.current;
     if (modelData) {
-      const mesh = modelData.children[0].children[1] as SkinnedMesh;
-
-      setSknnedMesh(mesh);
-      for (let i = 0; i < mesh.userData.targetNames.length; i++) {
-        if (mesh.userData.targetNames[i] === VISEME_SIL_USERDATA_NAME) {
-          setStartingIndex(i);
-          break;
+      modelData.traverse((child) => {
+        if (child instanceof Mesh) {
+          if (child.name === 'Wolf3D_Avatar') {
+            // const mesh = modelData.children[0].children[0] as SkinnedMesh;
+            setSknnedMesh(child as SkinnedMesh);
+            // iterate through blendshape names in order to find the beginning of the
+            // viseme sequence (viseme_sil + 14 next)
+            for (let i = 0; i < child.userData.targetNames.length; i++) {
+              if (child.userData.targetNames[i] === VISEME_SIL_USERDATA_NAME) {
+                setStartingIndex(i);
+                break;
+              }
+            }
+          }
         }
-      }
+      });
     }
   }, [props.modelRef.current]);
 

--- a/examples/chat/src/app/components/3dAvatar/Model.tsx
+++ b/examples/chat/src/app/components/3dAvatar/Model.tsx
@@ -2,9 +2,9 @@
 import { AdditionalPhonemeInfo, EmotionEvent } from '@inworld/web-sdk';
 import { useFrame, useLoader } from '@react-three/fiber';
 import { Suspense, useEffect, useRef, useState } from 'react';
-import { MathUtils } from 'three';
-import { SkinnedMesh } from 'three';
+import { MathUtils, Mesh, SkinnedMesh } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
+
 import { Animation } from './Animation';
 
 interface ModelProps {
@@ -30,17 +30,22 @@ export function Model(props: ModelProps) {
 
   useEffect(() => {
     if (modelData) {
-      console.log('modelData', modelData);
-      const mesh = modelData.children[0].children[1] as SkinnedMesh;
-      setSknnedMesh(mesh);
-      // iterate through blendshape names in order to find the beginning of the
-      // viseme sequence (viseme_sil + 14 next)
-      for (let i = 0; i < mesh.userData.targetNames.length; i++) {
-        if (mesh.userData.targetNames[i] === EYES_CLOSED) {
-          setEyesClosedIndex(i);
-          break;
+      modelData.traverse((child) => {
+        if (child instanceof Mesh) {
+          if (child.name === 'Wolf3D_Avatar') {
+            // const mesh = modelData.children[0].children[0] as SkinnedMesh;
+            setSknnedMesh(child as SkinnedMesh);
+            // iterate through blendshape names in order to find the beginning of the
+            // viseme sequence (viseme_sil + 14 next)
+            for (let i = 0; i < child.userData.targetNames.length; i++) {
+              if (child.userData.targetNames[i] === EYES_CLOSED) {
+                setEyesClosedIndex(i);
+                break;
+              }
+            }
+          }
         }
-      }
+      });
     }
   }, [modelData]);
   useEffect(() => {


### PR DESCRIPTION
## Description

This fixes a bug in WebSDK example Chat  with a change in mesh id's due to updating Three.js. This fix changes the targets from id based to the mesh name itself to prevent this issue from occurring again.

## Related Ticket

https://inworldai.atlassian.net/browse/CORE-4365
