### PR TITLE
fix: Fix release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,15 +68,20 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+      - name: Build version path
+        if: needs.npm-release.result == 'success'
+        run: |
+          echo "path=require('./packages${{ inputs.package }}/package.json').version" | sed 's/@inworld//g' >> $GITHUB_OUTPUT
+        id: extract-version-path
       - name: Extract version
         if: needs.npm-release.result == 'success'
         run: |
-          echo "version=$(yarn workspace ${{ inputs.package }} get:version)" >> $GITHUB_OUTPUT
+          echo "version=$(node -e "console.log(${{ steps.extract-version-path.outputs.path }})")" >> $GITHUB_OUTPUT
         id: extract-version
       - name: Extract changelog
         if: needs.npm-release.result == 'success'
         run: |
-          echo "changelog=yarn workspace ${{ inputs.package }} get:changelog" >> $GITHUB_OUTPUT
+          echo "changelog=./packages${{ inputs.package }}/CHANGELOG.md" | sed 's/@inworld//g' >> $GITHUB_OUTPUT
         id: extract-changelog
       - name: Extract release notes
         if: needs.npm-release.result == 'success'

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -7,8 +7,6 @@
  - `release:pack`,
  - `release:publish`,
  - `release:bump`,
- - `get:version`,
- - `get:changelog`,
  - `lint:lint`,
  - `lint:check`,
  - `prettier:check`,

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -33,9 +33,7 @@
     "prettier:check": "yarn prettier --check \"./**/*.{js,jsx,ts,tsx}\" --ignore-path ../../.eslintignore --config ../../.prettierrc.json",
     "prettier:format": "yarn prettier --write \"./**/*.{js,jsx,ts,tsx}\" --ignore-path ../../.eslintignore --config ../../.prettierrc.json",
     "test": "jest --no-cache --reporters=default",
-    "test:coverage": "jest --coverage",
-    "get:version": "(node -p \"require('./package.json').version\")",
-    "get:changelog": "cat CHANGELOG.md"
+    "test:coverage": "jest --coverage"
   },
   "devDependencies": {
     "@types/defer-promise": "^1.0.0",

--- a/packages/web-threejs/package.json
+++ b/packages/web-threejs/package.json
@@ -33,8 +33,6 @@
     "lint:fix": "yarn run lint:check --fix",
     "prettier:check": "yarn prettier --check \"./**/*.{js,jsx,ts,tsx}\" --ignore-path ../../.eslintignore --config ../../.prettierrc.json",
     "prettier:format": "yarn prettier --write \"./**/*.{js,jsx,ts,tsx}\" --ignore-path ../../.eslintignore --config ../../.prettierrc.json",
-    "get:version": "(node -p \"require('./package.json').version\")",
-    "get:changelog": "cat CHANGELOG.md",
     "docs": "npm run docs:clean && npm run docs:generate",
     "docs:clean": "npx rimraf docs",
     "docs:generate": "npx typedoc"


### PR DESCRIPTION
## Description

Yarn command for workspaces produces additional outputs (even with silence flag).
So it doesn't work for GitHub actions eval
That's why yarn commands were replaced by GitHub runs

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
