### PR TITLE
fix: Fix replacing player placeholder for narrated actions inside history

### DIFF
--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- Fix replacing player placeholder for narrated actions inside history
+
 ## [2.2.0] - 2024-01-20
 
 ### Added

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -99,6 +99,7 @@ export class ConnectionService<
       props || ({} as ConnectionProps<InworldPacketT, HistoryItemT>);
     this.history = new InworldHistory<InworldPacketT>({
       extension: this.connectionProps.extension,
+      user: this.connectionProps.user,
     });
 
     this.initializeHandlers();


### PR DESCRIPTION
## Description
Propagate missed user object to history

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
