### PR TITLE
feat: Add multi agent feature to chat example

### DIFF
--- a/examples/chat/src/app/chat/AdditionalActions.tsx
+++ b/examples/chat/src/app/chat/AdditionalActions.tsx
@@ -1,0 +1,141 @@
+import { InworldConnectionService, InworldTriggers } from '@inworld/web-core';
+import { AddReaction, MoreVert, Send, Start } from '@mui/icons-material';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  IconButton,
+  InputAdornment,
+  Popover,
+  Stack,
+  TextField,
+  Tooltip,
+} from '@mui/material';
+import React, { useCallback, useState } from 'react';
+
+import { INWORLD_COLORS } from '../helpers/colors';
+import { CHAT_VIEW } from '../types';
+
+export interface AdditionalActionsProps {
+  chatView: CHAT_VIEW;
+  connection: InworldConnectionService;
+  playWorkaroundSound: () => void;
+}
+
+export const AdditionalActions = (props: AdditionalActionsProps) => {
+  const [el, setEl] = useState<HTMLButtonElement | null>(null);
+  const [narration, setNarration] = useState('');
+  const [narratedActionDialogOpen, setNarratedActionDialogOpen] =
+    useState(false);
+
+  const onOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setEl(event.currentTarget);
+  };
+
+  const onClose = () => {
+    setEl(null);
+  };
+
+  const handleNarrationChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setNarration(e.target.value);
+    },
+    [],
+  );
+
+  const handleNarratedActionDialog = useCallback(() => {
+    setNarratedActionDialogOpen(true);
+  }, []);
+
+  const handleSendNarration = useCallback(() => {
+    if (narration) {
+      props.playWorkaroundSound();
+
+      props.connection?.sendNarratedAction(narration);
+
+      setNarration('');
+      setNarratedActionDialogOpen(false);
+    }
+  }, [props.connection, props.playWorkaroundSound, narration]);
+
+  const handleNextTurn = useCallback(() => {
+    props.playWorkaroundSound();
+
+    props.connection?.sendTrigger(InworldTriggers.MUTLI_AGENT_NEXT_TURN);
+
+    setEl(null);
+  }, [props.connection, props.playWorkaroundSound]);
+
+  return (
+    <>
+      <IconButton
+        onClick={onOpen}
+        size="small"
+        sx={{ color: INWORLD_COLORS.warmGray[50] }}
+      >
+        <MoreVert fontSize="small" />
+      </IconButton>
+
+      <Popover
+        open={!!el}
+        anchorEl={el}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 150,
+          horizontal: 'center',
+        }}
+        onClose={onClose}
+      >
+        <Stack sx={{ p: 2 }} spacing={2}>
+          <Box>
+            <Tooltip title="Send narrated action" placement="left">
+              <IconButton onClick={handleNarratedActionDialog}>
+                <AddReaction fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            {props.chatView === CHAT_VIEW.MULTI_AGENT_TEXT ? (
+              <Tooltip title="Next agents turn" placement="left">
+                <IconButton onClick={handleNextTurn}>
+                  <Start fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              ''
+            )}
+          </Box>
+        </Stack>
+      </Popover>
+
+      <Dialog
+        open={narratedActionDialogOpen}
+        onClose={() => setNarratedActionDialogOpen(false)}
+      >
+        <DialogContent>
+          <Box sx={{ m: 1 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Narrated action"
+              onChange={handleNarrationChange}
+              placeholder="Enter action to narrate"
+              InputLabelProps={{ shrink: true }}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={handleSendNarration}>
+                      <Send />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+                disableUnderline: true,
+              }}
+            />
+          </Box>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/examples/chat/src/app/chat/History.tsx
+++ b/examples/chat/src/app/chat/History.tsx
@@ -1,5 +1,6 @@
 import {
   Actor,
+  Character,
   CHAT_HISTORY_TYPE,
   HistoryItem,
   HistoryItemActor,
@@ -9,6 +10,7 @@ import {
 import { Box, Fade, Stack, Typography } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
 
+import { CircularRpmAvatar } from '../components/CircularRpmAvatar';
 import { getEmoji } from '../helpers/emoji';
 import { dateWithMilliseconds } from '../helpers/transform';
 import { CHAT_VIEW, EmotionsMap } from '../types';
@@ -24,6 +26,7 @@ import { Typing } from './Typing';
 
 interface HistoryProps {
   chatView: CHAT_VIEW;
+  characters: Character[];
   history: HistoryItem[];
   emotions: EmotionsMap;
   onInteractionEnd: (value: boolean) => void;
@@ -158,6 +161,9 @@ export const History = (props: HistoryProps) => {
             let messages = item.messages;
             let actorSource = 'AGENT';
             let message = item.messages?.[0];
+            const character = props.characters.find(
+              (c) => c.id === item.source.name,
+            );
 
             const title =
               item.type === CHAT_HISTORY_TYPE.ACTOR ||
@@ -198,6 +204,21 @@ export const History = (props: HistoryProps) => {
                       className="history-actor"
                       key={`PortalSimulatorChatHistoryActor-${index}`}
                     >
+                      <CircularRpmAvatar
+                        key={index}
+                        src={
+                          character?.assets?.rpmImageUriPortrait ??
+                          character?.assets?.avatarImg ??
+                          ''
+                        }
+                        name={character?.displayName}
+                        size="48px"
+                        sx={{
+                          display: ['none', 'flex'],
+                          mr: 1,
+                          float: 'left',
+                        }}
+                      />
                       {emoji && (
                         <Box className="simulator-message__emoji" fontSize={16}>
                           {emoji}

--- a/examples/chat/src/app/configuration/ConfigView.tsx
+++ b/examples/chat/src/app/configuration/ConfigView.tsx
@@ -32,22 +32,25 @@ export const ConfigView = (props: ConfigViewProps) => {
         <Card sx={{ mb: 2 }}>
           <CardContent>
             <Grid container spacing={2}>
-              <Grid item xs={12} sm={6}>
-                <CharacterName />
-              </Grid>
-              <Grid item xs={12} sm={6}>
-                <SceneName />
+              <Grid item xs={12} sm={12}>
+                <ChatView />
               </Grid>
             </Grid>
             <Grid container spacing={2}>
               <Grid item xs={12} sm={6}>
-                <PlayerName />
+                {props.chatView === CHAT_VIEW.MULTI_AGENT_TEXT ? (
+                  <SceneName />
+                ) : (
+                  <CharacterName />
+                )}
               </Grid>
               <Grid item xs={12} sm={6}>
-                <ChatView />
+                <PlayerName />
               </Grid>
             </Grid>
-            {props.chatView === CHAT_VIEW.TEXT && (
+            {[CHAT_VIEW.TEXT, CHAT_VIEW.MULTI_AGENT_TEXT].includes(
+              props.chatView!,
+            ) && (
               <Grid container spacing={2}>
                 <Grid item xs={12} sm={6}>
                   <Audio />

--- a/examples/chat/src/app/types.ts
+++ b/examples/chat/src/app/types.ts
@@ -2,6 +2,7 @@ import { EmotionEvent } from '@inworld/web-core';
 
 export enum CHAT_VIEW {
   TEXT = 'Text',
+  MULTI_AGENT_TEXT = 'Text (multi agents)',
   AVATAR = 'Avatar',
   INNEQUIN = 'Innequin',
 }


### PR DESCRIPTION
## Description

!!! NOT PUBLISHED FEATURE
NEED TO TEST USING INSTRUCTIONS FROM TESTME.md

- Add new chat mode to settings page (multi agents)
- Allow to chat with both characters
- Allow to overhear characters (call next turn trigger)

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-931

## Screenshots (if appropriate)
<img width="881" alt="Screenshot 2024-01-26 at 22 01 10" src="https://github.com/inworld-ai/inworld-web-sdk/assets/14924102/d3b5473b-be27-4bc9-85d8-c192d0e2e882">
<img width="876" alt="Screenshot 2024-01-26 at 22 03 05" src="https://github.com/inworld-ai/inworld-web-sdk/assets/14924102/6ebbf0f4-d801-4ef1-a3ba-15a01e86c989">
<img width="886" alt="Screenshot 2024-01-26 at 22 03 16" src="https://github.com/inworld-ai/inworld-web-sdk/assets/14924102/bcdc4483-a0a1-4169-a054-794eadcc9184">
<img width="861" alt="Screenshot 2024-01-26 at 22 03 59" src="https://github.com/inworld-ai/inworld-web-sdk/assets/14924102/9b272d12-7485-4de8-b815-5bf6f3632e22">


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
