### PR TITLE
fix: rolled back web-sdk to 2.2.0 for three.js examples

### DIFF
--- a/examples/innequin-react/package.json
+++ b/examples/innequin-react/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@inworld/web-core": "2.3.0",
+    "@inworld/web-core": "2.2.0",
     "@inworld/web-threejs": "1.0.0",
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.11.13",

--- a/examples/innequin-react/yarn.lock
+++ b/examples/innequin-react/yarn.lock
@@ -598,10 +598,10 @@
     defer-promise "^3.0.0"
     uuid "^9.0.0"
 
-"@inworld/web-core@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@inworld/web-core/-/web-core-2.3.0.tgz#988e590e242e706c5497449758e3be384b8b41f5"
-  integrity sha512-kXMl3Vkl/nXIMsUvn3DdB7/o4KrtUjOV1KXFPPgO7Aesnaf/jRZLWKu/mFRFbUQGzhpBGxdpT5iTrCYB516tNQ==
+"@inworld/web-core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@inworld/web-core/-/web-core-2.2.0.tgz#b02c33822092506127d09f077d65f844a8b66c1f"
+  integrity sha512-Z7u122IEocTo/MpTA3ty0jh2da6wULhv3wK6HiIwZq15QYUpaN/XrIt3d15C5UKoeGiij2vTpppHcHKtV8s8XA==
   dependencies:
     base64-arraybuffer "^1.0.2"
     defer-promise "^3.0.0"

--- a/examples/rpm-react/package.json
+++ b/examples/rpm-react/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@inworld/web-core": "2.3.0",
+    "@inworld/web-core": "2.2.0",
     "@inworld/web-threejs": "1.0.0",
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.11.13",

--- a/examples/rpm-react/yarn.lock
+++ b/examples/rpm-react/yarn.lock
@@ -598,10 +598,10 @@
     defer-promise "^3.0.0"
     uuid "^9.0.0"
 
-"@inworld/web-core@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@inworld/web-core/-/web-core-2.3.0.tgz#988e590e242e706c5497449758e3be384b8b41f5"
-  integrity sha512-kXMl3Vkl/nXIMsUvn3DdB7/o4KrtUjOV1KXFPPgO7Aesnaf/jRZLWKu/mFRFbUQGzhpBGxdpT5iTrCYB516tNQ==
+"@inworld/web-core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@inworld/web-core/-/web-core-2.2.0.tgz#b02c33822092506127d09f077d65f844a8b66c1f"
+  integrity sha512-Z7u122IEocTo/MpTA3ty0jh2da6wULhv3wK6HiIwZq15QYUpaN/XrIt3d15C5UKoeGiij2vTpppHcHKtV8s8XA==
   dependencies:
     base64-arraybuffer "^1.0.2"
     defer-promise "^3.0.0"


### PR DESCRIPTION
## Description

Rolling back the web-sdk version for the Three.js react example projects as changes are needed for multi-agent.
