### PR TITLE
fix: Start WebRTC session directly after WebSocket opening

### DIFF
--- a/examples/chat/src/app/components/innequin/animator/facial/Eye.tsx
+++ b/examples/chat/src/app/components/innequin/animator/facial/Eye.tsx
@@ -68,9 +68,12 @@ export function Eye(props: EyeProps) {
   // Blink Change Timer
   useEffect(() => {
     if (props.isReady && !isBlinking) {
-      blinkIntervalRef.current = setTimeout(() => {
-        setIsBlinkng(true);
-      }, randomInt(BLINK_INTERVAL_MIN_MS, BLINK_INTERVAL_MAX_MS));
+      blinkIntervalRef.current = setTimeout(
+        () => {
+          setIsBlinkng(true);
+        },
+        randomInt(BLINK_INTERVAL_MIN_MS, BLINK_INTERVAL_MAX_MS),
+      );
       return () => {
         clearTimeout(blinkIntervalRef.current);
       };

--- a/packages/web-core/__tests__/entities/scene.entity.spec.ts
+++ b/packages/web-core/__tests__/entities/scene.entity.spec.ts
@@ -60,7 +60,7 @@ test('should convert proto to scene', () => {
   expect(scene.characters[0].id).toEqual(agents[0].agentId);
   expect(scene.characters[1].id).toEqual(agents[1].agentId);
   expect(scene.characters[1].assets.avatarImg).toEqual(undefined);
-  expect(scene.history.length).toEqual(2);
+  expect(scene.history.length).toEqual(3);
 });
 
 test('should convert proto to scene without history items and agents', () => {

--- a/packages/web-core/src/components/history.ts
+++ b/packages/web-core/src/components/history.ts
@@ -126,10 +126,13 @@ export class InworldHistory<
     const utteranceId = packet.packetId.utteranceId;
     const interactionId = packet.packetId.interactionId;
 
-    const byId = characters.reduce((acc, character) => {
-      acc[character.id] = character;
-      return acc;
-    }, {} as { [key: string]: Character });
+    const byId = characters.reduce(
+      (acc, character) => {
+        acc[character.id] = character;
+        return acc;
+      },
+      {} as { [key: string]: Character },
+    );
     const itemCharacters = [];
 
     if (packet.routing.source.isCharacter) {

--- a/packages/web-core/src/connection/web-socket.connection.ts
+++ b/packages/web-core/src/connection/web-socket.connection.ts
@@ -40,6 +40,7 @@ interface SessionProps<InworldPacketT, HistoryItemT> {
 interface ConnectionProps {
   config?: InternalClientConfiguration;
   onDisconnect?: () => Awaitable<void>;
+  onReady?: () => Awaitable<void>;
   onError?: (err: Event | Error) => Awaitable<void>;
   onMessage?: (packet: ProtoPacket) => Awaitable<void>;
 }
@@ -96,6 +97,8 @@ export class WebSocketConnection<
       for (const packet of finalPackets) {
         write({ getPacket: () => packet });
       }
+
+      this.connectionProps.onReady?.();
     });
 
     this.ws = ws;

--- a/packages/web-core/src/entities/continuation/previous_dialog.entity.ts
+++ b/packages/web-core/src/entities/continuation/previous_dialog.entity.ts
@@ -52,7 +52,7 @@ export class PreviousDialog {
         ({
           actor: DialogActor.toProto(item.talker),
           text: item.phrase,
-        } as DialogHistoryHistoryItem),
+        }) as DialogHistoryHistoryItem,
     );
 
     return { history };

--- a/packages/web-core/src/entities/packets/audio.entity.ts
+++ b/packages/web-core/src/entities/packets/audio.entity.ts
@@ -34,7 +34,7 @@ export class AudioEvent {
           ({
             phoneme: info.phoneme,
             startOffsetS: parseFloat(info.startOffset),
-          } as AdditionalPhonemeInfo),
+          }) as AdditionalPhonemeInfo,
       ),
     });
   }

--- a/packages/web-core/src/entities/scene.entity.ts
+++ b/packages/web-core/src/entities/scene.entity.ts
@@ -1,6 +1,7 @@
 import {
   ActorType,
   Agent,
+  ControlEventAction,
   InworldPacket as ProtoPacket,
   LoadedScene,
   SessionHistoryResponse,
@@ -69,6 +70,26 @@ export class Scene {
         },
         [],
       ) ?? [];
+
+    // This is to ensure that the scene is in a consistent state.
+    // Interaction end means that all historical interactions are finished.
+    if (
+      history.length &&
+      history[history.length - 1].control?.action !==
+        ControlEventAction.INTERACTION_END
+    ) {
+      const lastPacket = history[history.length - 1];
+      history.push({
+        packetId: {
+          interactionId: lastPacket.packetId?.interactionId,
+        },
+        control: {
+          action: ControlEventAction.INTERACTION_END,
+        },
+        routing: { ...lastPacket.routing },
+        timestamp: lastPacket.timestamp,
+      });
+    }
 
     return new Scene({
       name,

--- a/packages/web-core/src/factories/event.ts
+++ b/packages/web-core/src/factories/event.ts
@@ -218,7 +218,7 @@ export class EventFactory {
       (name) =>
         ({
           name,
-        } as LoadCharactersCharacterName),
+        }) as LoadCharactersCharacterName,
     );
 
     const mutation = { loadCharacters: { name } } as MutationEvent;

--- a/packages/web-threejs/src/innequin/animator/facial/InnequinEyes.ts
+++ b/packages/web-threejs/src/innequin/animator/facial/InnequinEyes.ts
@@ -64,9 +64,12 @@ export class InnequinEyes {
 
   startBlinking() {
     if (!this.isBlinking) {
-      this.blinkTimerInterval = setTimeout(() => {
-        this.setBlinking(true);
-      }, randomInt(BLINK_INTERVAL_MIN_MS, BLINK_INTERVAL_MAX_MS));
+      this.blinkTimerInterval = setTimeout(
+        () => {
+          this.setBlinking(true);
+        },
+        randomInt(BLINK_INTERVAL_MIN_MS, BLINK_INTERVAL_MAX_MS),
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Otherwise we can an error:
Failed to execute 'addIceCandidate' on 'RTCPeerConnection': The remote description was null

## Related Ticket (for Inworld.ai developers)

https://github.com/inworld-ai/inworld-studio-fe/pull/1076


## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
