### PR TITLE
fix: Mark historical packets to distinguish them from runtime ones

### DIFF
--- a/packages/web-core/__tests__/entities/scene.entity.spec.ts
+++ b/packages/web-core/__tests__/entities/scene.entity.spec.ts
@@ -60,7 +60,7 @@ test('should convert proto to scene', () => {
   expect(scene.characters[0].id).toEqual(agents[0].agentId);
   expect(scene.characters[1].id).toEqual(agents[1].agentId);
   expect(scene.characters[1].assets.avatarImg).toEqual(undefined);
-  expect(scene.history.length).toEqual(3);
+  expect(scene.history.length).toEqual(2);
 });
 
 test('should convert proto to scene without history items and agents', () => {

--- a/packages/web-core/__tests__/services/connection.service.spec.ts
+++ b/packages/web-core/__tests__/services/connection.service.spec.ts
@@ -576,6 +576,7 @@ describe('send', () => {
             scene: SCENE,
             text: textEvent.text.text,
             type: CHAT_HISTORY_TYPE.ACTOR,
+            fromHistory: false,
           },
         ]);
       },

--- a/packages/web-core/src/components/history.ts
+++ b/packages/web-core/src/components/history.ts
@@ -13,6 +13,7 @@ interface InworldHistoryAddProps<InworldPacketT> {
   grpcAudioPlayer: GrpcAudioPlayback;
   packet: InworldPacketT;
   outgoing?: boolean;
+  fromHistory?: boolean;
 }
 
 export enum CHAT_HISTORY_TYPE {
@@ -30,6 +31,7 @@ export interface HistoryItemBase {
   interactionId?: string;
   source: Actor;
   type: CHAT_HISTORY_TYPE;
+  fromHistory?: boolean;
 }
 
 export interface HistoryItemActor extends HistoryItemBase {
@@ -119,6 +121,7 @@ export class InworldHistory<
     grpcAudioPlayer,
     packet,
     outgoing,
+    fromHistory = false,
   }: InworldHistoryAddProps<InworldPacketT>) {
     let historyItem: HistoryItem | undefined;
     let queueItem: HistoryItem | undefined;
@@ -154,6 +157,7 @@ export class InworldHistory<
           ...this.combineTextItem(packet),
           character: itemCharacters[0],
           characters: itemCharacters,
+          fromHistory,
         };
 
         if (grpcAudioPlayer.hasPacketInQueue({ utteranceId })) {
@@ -164,11 +168,10 @@ export class InworldHistory<
         break;
 
       case packet.isNarratedAction():
-        const actionItem = this.combineNarratedActionItem(
-          packet,
-          itemCharacters,
-          this.user,
-        );
+        const actionItem = {
+          ...this.combineNarratedActionItem(packet, itemCharacters, this.user),
+          fromHistory,
+        };
 
         if (
           grpcAudioPlayer.isCurrentPacket({ interactionId }) ||
@@ -181,7 +184,10 @@ export class InworldHistory<
         break;
 
       case packet.isTrigger():
-        historyItem = this.combineTriggerItem(packet, outgoing);
+        historyItem = {
+          ...this.combineTriggerItem(packet, outgoing),
+          fromHistory,
+        };
         break;
 
       case packet.isInteractionEnd():

--- a/packages/web-core/src/entities/scene.entity.ts
+++ b/packages/web-core/src/entities/scene.entity.ts
@@ -1,7 +1,6 @@
 import {
   ActorType,
   Agent,
-  ControlEventAction,
   InworldPacket as ProtoPacket,
   LoadedScene,
   SessionHistoryResponse,
@@ -70,26 +69,6 @@ export class Scene {
         },
         [],
       ) ?? [];
-
-    // This is to ensure that the scene is in a consistent state.
-    // Interaction end means that all historical interactions are finished.
-    if (
-      history.length &&
-      history[history.length - 1].control?.action !==
-        ControlEventAction.INTERACTION_END
-    ) {
-      const lastPacket = history[history.length - 1];
-      history.push({
-        packetId: {
-          interactionId: lastPacket.packetId?.interactionId,
-        },
-        control: {
-          action: ControlEventAction.INTERACTION_END,
-        },
-        routing: { ...lastPacket.routing },
-        timestamp: lastPacket.timestamp,
-      });
-    }
 
     return new Scene({
       name,

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -384,6 +384,7 @@ export class ConnectionService<
         grpcAudioPlayer: this.connectionProps.grpcAudioPlayer,
         characters: this.eventFactory.getCharacters(),
         packet: this.extension.convertPacketFromProto(packet),
+        fromHistory: true,
       }),
     );
 


### PR DESCRIPTION
## Description

Mark historical packets by `fromHistory` attribute

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
