### PR TITLE
feat: Connection management

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,13 +32,13 @@
   },
   "overrides": [
     {
-     "files": [
-       "examples/**/*.ts",
-       "examples/**/*.tsx"
+      "files": [
+        "examples/**/*.ts",
+        "examples/**/*.tsx"
       ],
-        "rules": {
-           "no-console": "off"   
-        }
+      "rules": {
+        "no-console": "off"   
+      }
     }
   ],
   "ignorePatterns": ["proto", "build"]

--- a/examples/chat/src/app/chat/AdditionalActions.tsx
+++ b/examples/chat/src/app/chat/AdditionalActions.tsx
@@ -112,7 +112,7 @@ export const AdditionalActions = (props: AdditionalActionsProps) => {
       let parameters: TriggerParameter[] | undefined;
 
       try {
-        parameters = parameters && JSON.parse(triggerParams);
+        parameters = triggerParams && JSON.parse(triggerParams);
       } catch (e) {
         console.warn('Invalid JSON format for trigger params');
         return;

--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Await for CLOSED WebSocket connection state after CLOSING one
 - Allow to change scene user parameters
+- Improve connection management
 
 ### Added
 

--- a/packages/web-core/__tests__/common/helpers.spec.ts
+++ b/packages/web-core/__tests__/common/helpers.spec.ts
@@ -1,4 +1,9 @@
-import { interpolate, isIOSMobile } from '../../src/common/helpers';
+import {
+  interpolate,
+  isIOSMobile,
+  objectsAreEqual,
+  safeJSONParse,
+} from '../../src/common/helpers';
 import { setNavigatorProperty } from '../helpers';
 
 describe('interpolate', () => {
@@ -46,5 +51,25 @@ describe('isIOSMobile', () => {
     setNavigatorProperty('userAgent', 'Android');
 
     expect(isIOSMobile()).toEqual(false);
+  });
+});
+
+describe('safeJSONParse', () => {
+  test('should return undefined for invalid JSON', () => {
+    expect(safeJSONParse('invalid')).toBeUndefined();
+  });
+
+  test('should return parsed object', () => {
+    expect(safeJSONParse('{"a": 1}')).toEqual({ a: 1 });
+  });
+});
+
+describe('objectsAreEqual', () => {
+  test('should return true for equal objects', () => {
+    expect(objectsAreEqual({ a: 1 }, { a: 1 }, ['a'])).toEqual(true);
+  });
+
+  test('should return false for different objects', () => {
+    expect(objectsAreEqual({ a: 1 }, { a: 2 }, ['a'])).toEqual(false);
   });
 });

--- a/packages/web-core/__tests__/connection/web-socket.connection.spec.ts
+++ b/packages/web-core/__tests__/connection/web-socket.connection.spec.ts
@@ -725,7 +725,7 @@ describe('update', () => {
       setTimeout(() => new Promise(emitHistoryResponseEvent(server)), 0),
     ]);
 
-    expect(write).toHaveBeenCalledTimes(4);
+    expect(write).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/packages/web-core/__tests__/factories/event.spec.ts
+++ b/packages/web-core/__tests__/factories/event.spec.ts
@@ -244,6 +244,22 @@ describe('event types', () => {
     expect(event.packetId?.conversationId).toEqual(conversationId);
   });
 
+  test('should generate trigger with character', () => {
+    const name = v4();
+    const event = factory.trigger(name, { character, conversationId });
+
+    expect(event).toHaveProperty('routing');
+    expect(event).toHaveProperty('timestamp');
+    expect(event.custom?.name).toEqual(name);
+    expect(event.routing?.target?.type).toEqual(ActorType.AGENT);
+    expect(event.routing?.target?.name).toEqual(character.id);
+    expect(event.packetId).toHaveProperty('packetId');
+    expect(event.packetId).toHaveProperty('interactionId');
+    expect(event.packetId).toHaveProperty('utteranceId');
+    expect(event.packetId).toHaveProperty('correlationId');
+    expect(event.packetId?.conversationId).toEqual(conversationId);
+  });
+
   test('should generate cancel response event', () => {
     const interactionId = v4();
     const utteranceId = [v4()];

--- a/packages/web-core/__tests__/factories/event.spec.ts
+++ b/packages/web-core/__tests__/factories/event.spec.ts
@@ -250,18 +250,16 @@ describe('event types', () => {
     const event = factory.cancelResponse({
       interactionId,
       utteranceId,
-      character,
     });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
-    expect(event.mutation.cancelResponses).toEqual({
+    expect(event.mutation?.cancelResponses).toEqual({
       interactionId,
       utteranceId,
     });
     expect(event.routing?.target).toEqual({
-      name: character.id,
-      type: ActorType.AGENT,
+      type: ActorType.WORLD,
     });
     expect(event.packetId).toHaveProperty('packetId');
     expect(event.packetId?.interactionId).toBeUndefined();

--- a/packages/web-core/__tests__/helpers/packet.ts
+++ b/packages/web-core/__tests__/helpers/packet.ts
@@ -35,11 +35,29 @@ export const getRouting = (character: Character) => ({
   ],
 });
 
-export const getPacketId = () =>
+export const getPacketId = (props?: { conversationId?: string }) =>
   new PacketId({
     packetId: v4(),
     interactionId: v4(),
     utteranceId: v4(),
+    conversationId: props?.conversationId ?? v4(),
+  });
+
+export const getAudioPacket = (props: {
+  character: Character;
+  chunk?: string;
+  packetId?: PacketId;
+}) =>
+  new InworldPacket({
+    packetId: props.packetId ?? getPacketId(),
+    routing: getRouting(props.character),
+    date: protoTimestamp(),
+    audio: {
+      chunk: props.chunk ?? v4(),
+      additionalPhonemeInfo: [],
+      durationMs: 0,
+    },
+    type: InworldPacketType.AUDIO,
   });
 
 export const getTextPacket = (props: {

--- a/packages/web-core/__tests__/services/connection.service.spec.ts
+++ b/packages/web-core/__tests__/services/connection.service.spec.ts
@@ -10,7 +10,6 @@ import {
   InworldPacket as ProtoPacket,
   TextEventSourceType,
 } from '../../proto/ai/inworld/packets/packets.pb';
-import { ConversationService } from '../../src';
 import {
   ConversationState,
   HistoryChangedProps,
@@ -32,10 +31,7 @@ import { Actor } from '../../src/entities/packets/routing.entity';
 import { SessionToken } from '../../src/entities/session_token.entity';
 import { EventFactory } from '../../src/factories/event';
 import { ConnectionService } from '../../src/services/connection.service';
-import {
-  SessionState,
-  StateSerializationService,
-} from '../../src/services/pb/state_serialization.service';
+import { ConversationService } from '../../src/services/conversation.service';
 import {
   capabilitiesProps,
   conversationId,
@@ -44,7 +40,6 @@ import {
   createAgent,
   emitSceneStatusEvent,
   generateSessionToken,
-  previousState,
   SCENE,
   session,
   user,
@@ -232,54 +227,6 @@ describe('history', () => {
 
     expect(getTranscript).toHaveBeenCalledTimes(1);
     expect(transcript).toEqual(result);
-  });
-});
-
-describe('getSessionState', () => {
-  let connection: ConnectionService;
-  let generateSessionToken: jest.Mock;
-
-  beforeEach(() => {
-    generateSessionToken = jest.fn(() => Promise.resolve(session));
-    connection = new ConnectionService({
-      name: SCENE,
-      onError,
-      grpcAudioPlayer,
-      generateSessionToken,
-      webRtcLoopbackBiDiSession,
-    });
-  });
-
-  test('should get state', async () => {
-    const expected: SessionState = {
-      state: previousState,
-      creationTime: protoTimestamp(),
-    };
-    const getSessionState = jest
-      .spyOn(StateSerializationService.prototype, 'getSessionState')
-      .mockImplementationOnce(() => Promise.resolve(expected));
-
-    const result = await connection.getSessionState();
-
-    expect(generateSessionToken).toHaveBeenCalledTimes(1);
-    expect(getSessionState).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(expected);
-  });
-
-  test('should catch error and pass it to handler', async () => {
-    const err = new Error();
-    const getSessionState = jest
-      .spyOn(StateSerializationService.prototype, 'getSessionState')
-      .mockImplementationOnce(() => {
-        throw err;
-      });
-
-    await connection.getSessionState();
-
-    expect(generateSessionToken).toHaveBeenCalledTimes(1);
-    expect(getSessionState).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(err);
   });
 });
 

--- a/packages/web-core/__tests__/services/session_state.service.spec.ts
+++ b/packages/web-core/__tests__/services/session_state.service.spec.ts
@@ -140,39 +140,6 @@ test('should save history from the last attempt', async () => {
   );
 });
 
-test('should propagate error', async () => {
-  const error = new Error('Should propagate error');
-
-  jest.spyOn(ConnectionService.prototype, 'getHistory').mockReturnValue([
-    {
-      interactionId: v4(),
-      type: CHAT_HISTORY_TYPE.INTERACTION_END,
-    } as HistoryItem,
-  ]);
-  jest.spyOn(global, 'setTimeout').mockImplementationOnce(setTimeoutMock);
-  jest
-    .spyOn(StateSerializationService.prototype, 'get')
-    .mockImplementationOnce(() => Promise.reject(error));
-
-  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
-
-  const onError = jest
-    .spyOn(global.console, 'error')
-    .mockImplementationOnce(jest.fn);
-  const connection = new ConnectionService();
-  const stateSerialization = new StateSerializationService(connection);
-
-  new SessionStateService(connection, stateSerialization);
-
-  window.dispatchEvent(new Event('blur'));
-
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  expect(onError).toHaveBeenCalledTimes(1);
-  expect(onError).toHaveBeenCalledWith(error);
-  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
-});
-
 test('should focus', () => {
   const connection = new ConnectionService();
   const stateSerialization = new StateSerializationService(connection);

--- a/packages/web-core/__tests__/services/session_state.service.spec.ts
+++ b/packages/web-core/__tests__/services/session_state.service.spec.ts
@@ -1,0 +1,182 @@
+import '../mocks/window.mock';
+
+import { v4 } from 'uuid';
+
+import { DEFAULT_SESSION_STATE_KEY } from '../../src/common/constants';
+import { protoTimestamp } from '../../src/common/helpers';
+import { CHAT_HISTORY_TYPE, HistoryItem } from '../../src/components/history';
+import { ConnectionService } from '../../src/services/connection.service';
+import { SessionStateService } from '../../src/services/session_state.service';
+import { StateSerializationService } from '../../src/services/wrappers/state_serialization.service';
+import { setTimeoutMock } from '../helpers';
+
+const expectedState = {
+  state: v4(),
+  creationTime: protoTimestamp(),
+  version: {
+    interactionId: v4(),
+  },
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+test('should clear', () => {
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+  const service = new SessionStateService(connection, stateSerialization);
+
+  const removeItem = jest.spyOn(
+    Object.getPrototypeOf(sessionStorage),
+    'removeItem',
+  );
+
+  service.clear();
+
+  expect(removeItem).toHaveBeenCalledWith(DEFAULT_SESSION_STATE_KEY);
+  expect(removeItem).toHaveBeenCalledTimes(1);
+});
+
+test('should destroy', () => {
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+  const service = new SessionStateService(connection, stateSerialization);
+
+  const clear = jest.spyOn(service, 'clear');
+  const removeEventListener = jest.spyOn(window, 'removeEventListener');
+
+  service.destroy();
+
+  expect(clear).toHaveBeenCalledTimes(1);
+
+  expect(removeEventListener).toHaveBeenCalledTimes(2);
+  expect(removeEventListener).toHaveBeenCalledWith('blur', expect.anything());
+  expect(removeEventListener).toHaveBeenCalledWith('focus', expect.anything());
+});
+
+test('should load session state', () => {
+  const getItem = jest.spyOn(Object.getPrototypeOf(sessionStorage), 'getItem');
+
+  SessionStateService.loadSessionState();
+
+  expect(getItem).toHaveBeenCalledWith(DEFAULT_SESSION_STATE_KEY);
+  expect(getItem).toHaveBeenCalledTimes(1);
+});
+
+test('should blur with empty history', async () => {
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+
+  new SessionStateService(connection, stateSerialization);
+
+  window.dispatchEvent(new Event('blur'));
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+});
+
+test('should save history from the 1st attempt', async () => {
+  jest.spyOn(ConnectionService.prototype, 'getHistory').mockReturnValue([
+    {
+      interactionId: v4(),
+      type: CHAT_HISTORY_TYPE.INTERACTION_END,
+    } as HistoryItem,
+  ]);
+  jest.spyOn(global, 'setTimeout').mockImplementationOnce(setTimeoutMock);
+  jest
+    .spyOn(StateSerializationService.prototype, 'get')
+    .mockImplementationOnce(() => Promise.resolve(expectedState));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+
+  new SessionStateService(connection, stateSerialization);
+
+  window.dispatchEvent(new Event('blur'));
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBe(
+    JSON.stringify(expectedState),
+  );
+});
+
+test('should save history from the last attempt', async () => {
+  jest.spyOn(ConnectionService.prototype, 'getHistory').mockReturnValue([
+    {
+      interactionId: v4(),
+      type: CHAT_HISTORY_TYPE.ACTOR,
+    } as HistoryItem,
+  ]);
+  jest
+    .spyOn(global, 'setTimeout')
+    .mockImplementationOnce(setTimeoutMock)
+    .mockImplementationOnce(setTimeoutMock)
+    .mockImplementationOnce(setTimeoutMock)
+    .mockImplementationOnce(setTimeoutMock);
+  jest
+    .spyOn(StateSerializationService.prototype, 'get')
+    .mockImplementationOnce(() => Promise.resolve(expectedState));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+
+  new SessionStateService(connection, stateSerialization);
+
+  window.dispatchEvent(new Event('blur'));
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBe(
+    JSON.stringify(expectedState),
+  );
+});
+
+test('should propagate error', async () => {
+  const error = new Error('Should propagate error');
+
+  jest.spyOn(ConnectionService.prototype, 'getHistory').mockReturnValue([
+    {
+      interactionId: v4(),
+      type: CHAT_HISTORY_TYPE.INTERACTION_END,
+    } as HistoryItem,
+  ]);
+  jest.spyOn(global, 'setTimeout').mockImplementationOnce(setTimeoutMock);
+  jest
+    .spyOn(StateSerializationService.prototype, 'get')
+    .mockImplementationOnce(() => Promise.reject(error));
+
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+
+  const onError = jest
+    .spyOn(global.console, 'error')
+    .mockImplementationOnce(jest.fn);
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+
+  new SessionStateService(connection, stateSerialization);
+
+  window.dispatchEvent(new Event('blur'));
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(onError).toHaveBeenCalledWith(error);
+  expect(sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY)).toBeFalsy();
+});
+
+test('should focus', () => {
+  const connection = new ConnectionService();
+  const stateSerialization = new StateSerializationService(connection);
+  new SessionStateService(connection, stateSerialization);
+
+  window.dispatchEvent(new Event('focus'));
+});

--- a/packages/web-core/__tests__/services/wrappers/feedback.service.spec.ts
+++ b/packages/web-core/__tests__/services/wrappers/feedback.service.spec.ts
@@ -1,23 +1,23 @@
-import '../mocks/window.mock';
+import '../../mocks/window.mock';
 
 import { v4 } from 'uuid';
 
 import {
   InteractionDislikeType,
   InteractionFeedback,
-} from '../../proto/ai/inworld/engine/v1/feedback.pb';
-import { GrpcAudioPlayback } from '../../src/components/sound/grpc_audio.playback';
-import { GrpcWebRtcLoopbackBiDiSession } from '../../src/components/sound/grpc_web_rtc_loopback_bidi.session';
-import { DislikeType, Feedback } from '../../src/entities/feedback.entity';
-import { ConnectionService } from '../../src/services/connection.service';
-import { FeedbackService } from '../../src/services/feedback.service';
-import { FeedbackService as FeedbackPbService } from '../../src/services/pb/feedback.service';
+} from '../../../proto/ai/inworld/engine/v1/feedback.pb';
+import { GrpcAudioPlayback } from '../../../src/components/sound/grpc_audio.playback';
+import { GrpcWebRtcLoopbackBiDiSession } from '../../../src/components/sound/grpc_web_rtc_loopback_bidi.session';
+import { DislikeType, Feedback } from '../../../src/entities/feedback.entity';
+import { ConnectionService } from '../../../src/services/connection.service';
+import { FeedbackService as FeedbackPbService } from '../../../src/services/pb/feedback.service';
+import { FeedbackService } from '../../../src/services/wrappers/feedback.service';
 import {
   createCharacter,
   generateSessionToken,
   SCENE,
   session,
-} from '../helpers';
+} from '../../helpers';
 
 const grpcAudioPlayer = new GrpcAudioPlayback();
 const webRtcLoopbackBiDiSession = new GrpcWebRtcLoopbackBiDiSession();

--- a/packages/web-core/__tests__/services/wrappers/state_serialization.service.spec.ts
+++ b/packages/web-core/__tests__/services/wrappers/state_serialization.service.spec.ts
@@ -1,0 +1,32 @@
+import '../../mocks/window.mock';
+
+import { v4 } from 'uuid';
+
+import { protoTimestamp } from '../../../src/common/helpers';
+import { ConnectionService } from '../../../src/services/connection.service';
+import { StateSerializationService } from '../../../src/services/pb/state_serialization.service';
+import { StateSerializationService as Wrapper } from '../../../src/services/wrappers/state_serialization.service';
+
+test('should return session state with version', async () => {
+  const connection = new ConnectionService();
+  const expected = {
+    state: v4(),
+    creationTime: protoTimestamp(),
+    version: {
+      interactionId: v4(),
+    },
+  };
+
+  const getSessionState = jest
+    .spyOn(StateSerializationService.prototype, 'getSessionState')
+    .mockImplementationOnce(() => Promise.resolve(expected));
+  const ensureSessionToken = jest
+    .spyOn(ConnectionService.prototype, 'ensureSessionToken')
+    .mockImplementation(jest.fn());
+
+  const result = await new Wrapper(connection).get();
+
+  expect(getSessionState).toHaveBeenCalledTimes(1);
+  expect(ensureSessionToken).toHaveBeenCalledTimes(1);
+  expect(result).toEqual(expected);
+});

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inworld/web-core",
-  "version": "2.8.0",
+  "version": "2.9.0-beta.4",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inworld/web-core",
-  "version": "2.9.0-beta.4",
+  "version": "2.9.0-beta.4a",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/web-core/src/clients/inworld.client.ts
+++ b/packages/web-core/src/clients/inworld.client.ts
@@ -220,12 +220,16 @@ export class InworldClient<
       extension: this.extension,
     });
 
-    return new InworldConnectionService<InworldPacketT>({
+    const inworldConnection = new InworldConnectionService<InworldPacketT>({
       connection,
       grpcAudioPlayer,
       grpcAudioRecorder,
       webRtcLoopbackBiDiSession,
     });
+
+    inworldConnection.clearState();
+
+    return inworldConnection;
   }
 
   private buildConfiguration(): InternalClientConfiguration {

--- a/packages/web-core/src/common/constants.ts
+++ b/packages/web-core/src/common/constants.ts
@@ -9,5 +9,5 @@ export const CHARACTER_PATTERN =
 
 export const DEFAULT_SESSION_STATE_MAX_ATTEMPTS = 3;
 export const DEFAULT_SESSION_STATE_KEY = 'inworldSessionState';
-export const DEFAULT_SESSION_STATE_INTERVAL = 60 * 1000; // 1 minute
+export const DEFAULT_SESSION_STATE_INTERVAL = 5 * 60 * 1000; // 5 minute
 export const DEFAULT_SESSION_STATE_ATTEMPTS_INTERVAL = 1000; // 1 second

--- a/packages/web-core/src/common/constants.ts
+++ b/packages/web-core/src/common/constants.ts
@@ -6,3 +6,8 @@ export const SCENE_PATTERN =
   /^workspaces\/([a-z0-9-_]{1,61})\/(characters|scenes)\/([a-z0-9-_]{1,61})$/iu;
 export const CHARACTER_PATTERN =
   /^workspaces\/([a-z0-9-_]{1,61})\/characters\/([a-z0-9-_]{1,61})$/iu;
+
+export const DEFAULT_SESSION_STATE_MAX_ATTEMPTS = 3;
+export const DEFAULT_SESSION_STATE_KEY = 'inworldSessionState';
+export const DEFAULT_SESSION_STATE_INTERVAL = 60 * 1000; // 1 minute
+export const DEFAULT_SESSION_STATE_ATTEMPTS_INTERVAL = 1000; // 1 second

--- a/packages/web-core/src/common/data_structures.ts
+++ b/packages/web-core/src/common/data_structures.ts
@@ -299,3 +299,11 @@ export interface SceneHistoryItem {
   character: Character;
   packet: ProtoPacket;
 }
+
+export interface SessionState {
+  state?: string;
+  creationTime?: string;
+  version?: {
+    interactionId?: string;
+  };
+}

--- a/packages/web-core/src/common/data_structures.ts
+++ b/packages/web-core/src/common/data_structures.ts
@@ -74,10 +74,21 @@ export interface SessionControlProps {
   sessionHistory?: SessionHistoryRequest;
 }
 
+export interface sessionContunuationConfig {
+  storage?: {
+    setItem: (value: string) => Awaitable<void>;
+    getItem: () => Awaitable<string>;
+  };
+  interval?: number;
+  attemptsInterval?: number;
+  maxAttempts?: number;
+}
+
 export interface ConnectionConfig {
   autoReconnect?: boolean;
   disconnectTimeout?: number;
   gateway?: Gateway;
+  sessionContunuation?: sessionContunuationConfig;
 }
 
 export interface HistoryConfig {
@@ -119,6 +130,7 @@ export enum ConnectionState {
   ACTIVE = 'ACTIVE',
   ACTIVATING = 'ACTIVATING',
   INACTIVE = 'INACTIVE',
+  RECONNECTING = 'RECONNECTING',
 }
 
 export enum AudioSessionState {
@@ -243,7 +255,7 @@ export enum ConversationParticipant {
 }
 
 export interface HistoryChangedProps<HistoryItemT = HistoryItem> {
-  diff: HistoryItemT[];
+  diff: { added?: HistoryItemT[]; removed?: HistoryItemT[] };
   conversationId?: string;
 }
 

--- a/packages/web-core/src/common/helpers.ts
+++ b/packages/web-core/src/common/helpers.ts
@@ -6,3 +6,21 @@ export const isIOSMobile = (): boolean =>
 
 export const interpolate = (p: number): number =>
   0.5 - Math.cos(p * Math.PI) / 2;
+
+export const safeJSONParse = <T = any>(str: string): T | undefined => {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return undefined;
+  }
+};
+
+export const objectsAreEqual = <T>(a: T, b: T, keys: (keyof T)[]) => {
+  for (const key of keys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/packages/web-core/src/components/history.ts
+++ b/packages/web-core/src/components/history.ts
@@ -97,6 +97,7 @@ export interface HistoryItemSceneChange {
   addedCharacters?: Character[];
   removedCharacters?: Character[];
   conversationId?: string;
+  fromHistory?: boolean;
 }
 
 export interface HistoryItemConversationUpdate {
@@ -109,6 +110,7 @@ export interface HistoryItemConversationUpdate {
   currentCharacters?: Character[];
   addedCharacters?: Character[];
   removedCharacters?: Character[];
+  fromHistory?: boolean;
 }
 
 export type HistoryItem =

--- a/packages/web-core/src/components/history.ts
+++ b/packages/web-core/src/components/history.ts
@@ -477,17 +477,19 @@ export class InworldHistory<
     );
   }
 
-  filter(props: { utteranceId: string[]; interactionId: string }) {
-    const { interactionId, utteranceId } = props;
+  filter(props: {
+    history?: (item: HistoryItem) => boolean;
+    queue?: (item: HistoryItem) => boolean;
+  }) {
+    if (props.history) {
+      this.history = this.history.filter(props.history);
+    }
 
-    this.history = this.history.filter(
-      (item: HistoryItem) => !utteranceId.includes(item.id),
-    );
+    if (props.queue) {
+      this.queue = this.queue.filter(props.queue);
+    }
 
-    this.queue = this.queue.filter(
-      (item: HistoryItem) =>
-        item.interactionId !== interactionId && !utteranceId.includes(item.id),
-    );
+    return this.history;
   }
 
   clear() {
@@ -729,12 +731,10 @@ export class InworldHistory<
       );
 
       return conversation?.service?.getCharacters() || [];
-    } else if (participants.length) {
+    } else {
       return participants
         .filter((x) => x.isCharacter && byId[x.name])
         .map((x) => byId[x.name]);
-    } else {
-      return [];
     }
   }
 }

--- a/packages/web-core/src/connection/web-socket.connection.ts
+++ b/packages/web-core/src/connection/web-socket.connection.ts
@@ -60,6 +60,7 @@ export interface QueueItem<InworldPacketT> {
   getPacket: () => ProtoPacket;
   afterWriting?: (packet: InworldPacketT) => void;
   beforeWriting?: (packet: InworldPacketT) => Promise<void>;
+  convertPacket?: (packet: ProtoPacket) => ProtoPacket;
 }
 
 export interface Connection<InworldPacketT> {
@@ -180,7 +181,7 @@ export class WebSocketConnection<
     });
     const needHistory =
       this.connectionProps.config.history?.previousState &&
-      !!finalPackets.find((p) => p.sessionControl?.continuation);
+      !!finalPackets.find((p) => p.control?.sessionConfiguration?.continuation);
 
     for (const packet of finalPackets) {
       write({
@@ -231,7 +232,8 @@ export class WebSocketConnection<
   }
 
   async write(item: QueueItem<InworldPacketT>) {
-    const packet = item.getPacket();
+    const originalPacket = item.getPacket();
+    const packet = item.convertPacket?.(originalPacket) ?? originalPacket;
     const inworldPacket = this.extension.convertPacketFromProto(packet);
     await item.beforeWriting?.(inworldPacket);
     this.ws.send(JSON.stringify(packet));
@@ -288,7 +290,10 @@ export class WebSocketConnection<
     firstLoad?: boolean;
     needHistory: boolean;
     ws: WebSocket;
-    write: (item: QueueItem<InworldPacketT>) => void;
+    write: (
+      item: QueueItem<InworldPacketT>,
+      convertPacket?: (packet: ProtoPacket) => ProtoPacket,
+    ) => void;
     resolve: (value: LoadedScene) => void;
     reject: (reason: InworldError) => void;
   }) {

--- a/packages/web-core/src/entities/error.entity.ts
+++ b/packages/web-core/src/entities/error.entity.ts
@@ -36,7 +36,7 @@ interface ResourceNotFoundDetails {
   resourceType?: ErrorResourceType;
 }
 
-interface InworldStatus {
+export interface InworldStatus {
   errorType?: ErrorType;
   reconnectTime?: string;
   reconnectType?: ErrorReconnectionType;

--- a/packages/web-core/src/factories/event.ts
+++ b/packages/web-core/src/factories/event.ts
@@ -1,6 +1,7 @@
 import { v4 } from 'uuid';
 
 import {
+  Actor,
   ActorType,
   Agent,
   AudioSessionStartPayloadMicrophoneMode,
@@ -34,7 +35,6 @@ import { ItemOperation } from '../entities/entities/item_operation';
 export interface SendCancelResponsePacketParams {
   interactionId?: string;
   utteranceId?: string[];
-  character: Character;
 }
 
 export class EventFactory {
@@ -126,7 +126,9 @@ export class EventFactory {
           utteranceId: params.utteranceId,
         },
       },
-      routing: this.routing({ character: params.character }),
+      routing: this.routing({
+        target: { type: ActorType.WORLD },
+      }),
     };
   }
 
@@ -327,7 +329,7 @@ export class EventFactory {
     return {
       ...this.baseProtoPacket({ correlationId: true, conversationId }),
       ...(character && {
-        routing: this.routing({ character }),
+        target: { name: character.id, type: ActorType.AGENT },
       }),
       custom: {
         name,
@@ -337,12 +339,10 @@ export class EventFactory {
     };
   }
 
-  private routing(props?: { character: Character }): Routing {
+  private routing(props?: { target: Actor }): Routing {
     return {
       source: { type: ActorType.PLAYER },
-      ...(props?.character && {
-        target: { type: ActorType.AGENT, name: props.character.id },
-      }),
+      ...(props?.target && { target: props.target }),
     };
   }
 

--- a/packages/web-core/src/factories/event.ts
+++ b/packages/web-core/src/factories/event.ts
@@ -329,7 +329,9 @@ export class EventFactory {
     return {
       ...this.baseProtoPacket({ correlationId: true, conversationId }),
       ...(character && {
-        target: { name: character.id, type: ActorType.AGENT },
+        routing: this.routing({
+          target: { name: character.id, type: ActorType.AGENT },
+        }),
       }),
       custom: {
         name,

--- a/packages/web-core/src/index.ts
+++ b/packages/web-core/src/index.ts
@@ -76,12 +76,12 @@ import { TextEvent } from './entities/packets/text.entity';
 import { TriggerEvent } from './entities/packets/trigger.entity';
 import { SessionToken } from './entities/session_token.entity';
 import { ConversationService } from './services/conversation.service';
+import { InworldConnectionService } from './services/inworld_connection.service';
+import { SessionState } from './services/pb/state_serialization.service';
 import {
   FeedbackDislikeProps,
   FeedbackLikeProps,
-} from './services/feedback.service';
-import { InworldConnectionService } from './services/inworld_connection.service';
-import { SessionState } from './services/pb/state_serialization.service';
+} from './services/wrappers/feedback.service';
 
 export {
   Actor,

--- a/packages/web-core/src/index.ts
+++ b/packages/web-core/src/index.ts
@@ -18,6 +18,7 @@ import {
   HistoryChangedProps,
   ItemsInEntitiesOperationType,
   MicrophoneMode,
+  SessionState,
   StopAudioPlayback,
   TaskParameter,
   TriggerParameter,
@@ -77,7 +78,6 @@ import { TriggerEvent } from './entities/packets/trigger.entity';
 import { SessionToken } from './entities/session_token.entity';
 import { ConversationService } from './services/conversation.service';
 import { InworldConnectionService } from './services/inworld_connection.service';
-import { SessionState } from './services/pb/state_serialization.service';
 import {
   FeedbackDislikeProps,
   FeedbackLikeProps,

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -592,7 +592,7 @@ export class ConnectionService<
     const status = err.details?.[0];
     const interactionIds = Object.keys(this.packetsInProgress);
     let needToReopen =
-      interactionIds.length &&
+      !!interactionIds.length &&
       [ErrorReconnectionType.IMMEDIATE, ErrorReconnectionType.TIMEOUT].includes(
         status?.reconnectType,
       );
@@ -608,6 +608,8 @@ export class ConnectionService<
           ...this.session,
           expirationTime: undefined,
         };
+        needToReopen = true;
+        status.reconnectType = ErrorReconnectionType.IMMEDIATE;
         break;
       case ErrorType.SESSION_INVALID:
         this.session = undefined;
@@ -622,6 +624,8 @@ export class ConnectionService<
         this.scene = new Scene({
           name: this.getSceneName(),
         });
+        needToReopen = true;
+        status.reconnectType = ErrorReconnectionType.IMMEDIATE;
         break;
     }
 

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -156,6 +156,12 @@ export class ConnectionService<
     return this.state === ConnectionState.ACTIVE;
   }
 
+  isConnecting() {
+    return [ConnectionState.ACTIVATING, ConnectionState.RECONNECTING].includes(
+      this.state,
+    );
+  }
+
   isInactive() {
     return this.state === ConnectionState.INACTIVE;
   }
@@ -166,6 +172,10 @@ export class ConnectionService<
 
   getSceneName() {
     return this.scene.name;
+  }
+
+  getSessionId() {
+    return this.session?.sessionId;
   }
 
   getCurrentAudioConversation() {

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -650,6 +650,7 @@ export class ConnectionService<
     // Also, we need to stop reconnection attempts if the reconnection is impossible due some reasons.
     if (
       (sameError && this.previousError.attempts >= (status.maxRetries ?? 0)) ||
+      !status ||
       (status &&
         ![
           ErrorReconnectionType.IMMEDIATE,

--- a/packages/web-core/src/services/conversation.service.ts
+++ b/packages/web-core/src/services/conversation.service.ts
@@ -121,10 +121,12 @@ export class ConversationService<
 
     if (charactersToAdd.length) {
       await this.addCharacters(charactersToAdd);
-      characters = (await this.connection.getCharacters()).filter((c) =>
-        charactersNamesOnly.includes(c.resourceName),
-      );
+      characters = await this.connection.getCharacters();
     }
+
+    characters = characters.filter((c) =>
+      charactersNamesOnly.includes(c.resourceName),
+    );
 
     // Update conversation
     const conversationParticipants = characters.map((c) => c.id);

--- a/packages/web-core/src/services/pb/state_serialization.service.ts
+++ b/packages/web-core/src/services/pb/state_serialization.service.ts
@@ -1,6 +1,9 @@
 import { StateSerialization } from '../../../proto/ai/inworld/engine/v1/state_serialization.pb';
 import { SCENE_PATTERN } from '../../common/constants';
-import { InternalClientConfiguration } from '../../common/data_structures';
+import {
+  InternalClientConfiguration,
+  SessionState,
+} from '../../common/data_structures';
 import { SessionToken } from '../../entities/session_token.entity';
 import { PbService } from './pb.service';
 
@@ -8,14 +11,6 @@ export interface getSessionStateProps {
   config: InternalClientConfiguration;
   session: SessionToken;
   scene: string;
-}
-
-export interface SessionState {
-  state?: string;
-  creationTime?: string;
-  version?: {
-    interactionId?: string;
-  };
 }
 
 export class StateSerializationService extends PbService {

--- a/packages/web-core/src/services/pb/state_serialization.service.ts
+++ b/packages/web-core/src/services/pb/state_serialization.service.ts
@@ -11,8 +11,11 @@ export interface getSessionStateProps {
 }
 
 export interface SessionState {
-  state: string;
-  creationTime: string;
+  state?: string;
+  creationTime?: string;
+  version?: {
+    interactionId?: string;
+  };
 }
 
 export class StateSerializationService extends PbService {
@@ -32,8 +35,13 @@ export class StateSerializationService extends PbService {
     );
 
     return {
-      state: res.state.toString(),
-      creationTime: res.creationTime.toString(),
+      state: res.state?.toString(),
+      creationTime: res.creationTime?.toString(),
+      ...(res.version?.interactionId && {
+        version: {
+          interactionId: res.version.interactionId,
+        },
+      }),
     } as SessionState;
   }
 }

--- a/packages/web-core/src/services/session_state.service.ts
+++ b/packages/web-core/src/services/session_state.service.ts
@@ -140,9 +140,7 @@ export class SessionStateService<
           JSON.stringify(sessionState),
         );
       }
-    } catch (error) {
-      this.connection.onError(error);
-    }
+    } catch (e) {}
   }
 
   private setAutoSaveInterval() {

--- a/packages/web-core/src/services/session_state.service.ts
+++ b/packages/web-core/src/services/session_state.service.ts
@@ -1,0 +1,168 @@
+import { SessionState } from '../../proto/ai/inworld/engine/v1/state_serialization.pb';
+import {
+  DEFAULT_SESSION_STATE_ATTEMPTS_INTERVAL,
+  DEFAULT_SESSION_STATE_INTERVAL,
+  DEFAULT_SESSION_STATE_KEY,
+  DEFAULT_SESSION_STATE_MAX_ATTEMPTS,
+} from '../common/constants';
+import { safeJSONParse } from '../common/helpers';
+import { CHAT_HISTORY_TYPE } from '../components/history';
+import { InworldPacket } from '../entities/packets/inworld_packet.entity';
+import { ConnectionService } from './connection.service';
+import { StateSerializationService } from './wrappers/state_serialization.service';
+
+export class SessionStateService<
+  InworldPacketT extends InworldPacket = InworldPacket,
+> {
+  private connection: ConnectionService;
+  private stateSerialization: StateSerializationService<InworldPacketT>;
+
+  // Try to save session state every N milliseconds is user is active.
+  // See DEFAULT_SESSION_STATE_INTERVAL.
+  private autoSaveIntervalId: NodeJS.Timeout | undefined;
+  private maxAttempts = DEFAULT_SESSION_STATE_MAX_ATTEMPTS;
+
+  private interactionEndTimeout: NodeJS.Timeout | undefined;
+
+  private isBlurred = false;
+  private isSaving = false;
+
+  constructor(
+    connection: ConnectionService,
+    stateSerialization: StateSerializationService<InworldPacketT>,
+  ) {
+    this.connection = connection;
+    this.stateSerialization = stateSerialization;
+
+    window.addEventListener('blur', this.onWindowBlur.bind(this));
+    window.addEventListener('focus', this.onWindowFocus.bind(this));
+
+    this.setAutoSaveInterval();
+  }
+
+  clear() {
+    sessionStorage.removeItem(DEFAULT_SESSION_STATE_KEY);
+  }
+
+  destroy() {
+    this.clear();
+    this.clearAutoSaveInterval();
+    this.clearInteractionEndTimeout();
+
+    window.removeEventListener('blur', this.onWindowBlur.bind(this));
+    window.removeEventListener('focus', this.onWindowFocus.bind(this));
+  }
+
+  static loadSessionState() {
+    return sessionStorage.getItem(DEFAULT_SESSION_STATE_KEY);
+  }
+
+  private onWindowBlur() {
+    this.isBlurred = true;
+
+    this.clearAutoSaveInterval();
+    this.tryToSaveState();
+  }
+
+  private onWindowFocus() {
+    this.isBlurred = false;
+
+    this.setAutoSaveInterval();
+  }
+
+  private tryToSaveState() {
+    if (this.isSaving) {
+      return;
+    }
+
+    this.isSaving = true;
+
+    const history = this.connection.getHistory();
+    const lastItem = history[history.length - 1];
+    const saved = SessionStateService.loadSessionState();
+    const sessionState = saved ? safeJSONParse<SessionState>(saved) : undefined;
+
+    // Don't save session state if it's already saved.
+    if (
+      !lastItem ||
+      (lastItem.interactionId &&
+        lastItem.interactionId === sessionState?.version?.interactionId)
+    ) {
+      this.isSaving = false;
+      return;
+    }
+
+    let attempts = 0;
+
+    const save = () => {
+      this.interactionEndTimeout = setTimeout(
+        async () => {
+          this.clearInteractionEndTimeout();
+
+          attempts++;
+
+          const history = this.connection.getHistory();
+          const lastItem = history[history.length - 1];
+
+          // Try to wait for interaction end event before saving session state.
+          // If all attempts are failed, just save session state here.
+          // Or save session state if last item in history is interaction end event.
+          if (
+            attempts > this.maxAttempts ||
+            lastItem?.type === CHAT_HISTORY_TYPE.INTERACTION_END
+          ) {
+            await this.saveSessionState();
+            this.isSaving = false;
+            return;
+          } else if (attempts <= this.maxAttempts) {
+            save();
+          }
+        },
+        DEFAULT_SESSION_STATE_ATTEMPTS_INTERVAL * (attempts + 1) +
+          DEFAULT_SESSION_STATE_ATTEMPTS_INTERVAL *
+            Math.pow(2, attempts) *
+            attempts,
+      );
+    };
+
+    save();
+  }
+
+  private async saveSessionState() {
+    this.clearAutoSaveInterval();
+
+    try {
+      const sessionState = await this.stateSerialization.get();
+
+      if (sessionState?.state) {
+        sessionStorage.setItem(
+          DEFAULT_SESSION_STATE_KEY,
+          JSON.stringify(sessionState),
+        );
+      }
+    } catch (error) {
+      this.connection.onError(error);
+    }
+  }
+
+  private setAutoSaveInterval() {
+    this.clearAutoSaveInterval();
+    this.autoSaveIntervalId = setInterval(() => {
+      if (!this.isBlurred) {
+        this.tryToSaveState();
+      }
+    }, DEFAULT_SESSION_STATE_INTERVAL);
+  }
+
+  private clearAutoSaveInterval() {
+    clearInterval(this.autoSaveIntervalId);
+
+    this.autoSaveIntervalId = undefined;
+  }
+
+  private clearInteractionEndTimeout() {
+    clearTimeout(this.interactionEndTimeout);
+
+    this.interactionEndTimeout = undefined;
+  }
+}

--- a/packages/web-core/src/services/wrappers/feedback.service.ts
+++ b/packages/web-core/src/services/wrappers/feedback.service.ts
@@ -1,7 +1,7 @@
-import { DislikeType, Feedback } from '../entities/feedback.entity';
-import { InworldPacket } from '../entities/packets/inworld_packet.entity';
-import { ConnectionService } from './connection.service';
-import { FeedbackService as PbService } from './pb/feedback.service';
+import { DislikeType, Feedback } from '../../entities/feedback.entity';
+import { InworldPacket } from '../../entities/packets/inworld_packet.entity';
+import { ConnectionService } from '../connection.service';
+import { FeedbackService as PbService } from '../pb/feedback.service';
 
 interface SendFeedbackProps {
   comment?: string;

--- a/packages/web-core/src/services/wrappers/state_serialization.service.ts
+++ b/packages/web-core/src/services/wrappers/state_serialization.service.ts
@@ -1,3 +1,5 @@
+import { ProtoError, SessionState } from '../../common/data_structures';
+import { ErrorType, InworldError } from '../../entities/error.entity';
 import { InworldPacket } from '../../entities/packets/inworld_packet.entity';
 import { ConnectionService } from '../connection.service';
 import { StateSerializationService as PbService } from '../pb/state_serialization.service';
@@ -12,13 +14,31 @@ export class StateSerializationService<
     this.connection = connection;
   }
 
-  async get() {
-    const session = await this.connection.ensureSessionToken();
+  async get(attempt: number = 0): Promise<SessionState> {
+    let session = await this.connection.ensureSessionToken();
 
-    return this.service.getSessionState({
-      config: this.connection.getConfig(),
-      session,
-      scene: this.connection.getSceneName(),
-    });
+    try {
+      return await this.service.getSessionState({
+        config: this.connection.getConfig(),
+        session,
+        scene: this.connection.getSceneName(),
+      });
+    } catch (protoErr: any) {
+      if (attempt) {
+        throw protoErr;
+      }
+
+      const err = InworldError.fromProto(protoErr as ProtoError);
+      const status = err.details?.[0];
+
+      switch (status?.errorType) {
+        case ErrorType.SESSION_TOKEN_EXPIRED:
+        case ErrorType.SESSION_TOKEN_INVALID:
+          await this.connection.ensureSessionToken();
+          return this.get(attempt + 1);
+        default:
+          return;
+      }
+    }
   }
 }

--- a/packages/web-core/src/services/wrappers/state_serialization.service.ts
+++ b/packages/web-core/src/services/wrappers/state_serialization.service.ts
@@ -1,0 +1,24 @@
+import { InworldPacket } from '../../entities/packets/inworld_packet.entity';
+import { ConnectionService } from '../connection.service';
+import { StateSerializationService as PbService } from '../pb/state_serialization.service';
+
+export class StateSerializationService<
+  InworldPacketT extends InworldPacket = InworldPacket,
+> {
+  private connection: ConnectionService<InworldPacketT>;
+  private service = new PbService();
+
+  constructor(connection: ConnectionService<InworldPacketT>) {
+    this.connection = connection;
+  }
+
+  async get() {
+    const session = await this.connection.ensureSessionToken();
+
+    return this.service.getSessionState({
+      config: this.connection.getConfig(),
+      session,
+      scene: this.connection.getSceneName(),
+    });
+  }
+}


### PR DESCRIPTION
## Description

#### How to simulate the errors?
Send a trigger `inworld.debug.error` with one of the following parameters:

- [{"name":"errorType","value":"SESSION_TOKEN_EXPIRED"}]
- [{"name":"errorType","value":"SESSION_TOKEN_EXPIRED"},{"name":"reconnectType","value":"TIMEOUT"}, {"name":"reconnectTime","value":"***"}]
- [{"name":"errorType","value":"SESSION_TOKEN_INVALID"}]
- [{"name":"errorType","value":"SESSION_TOKEN_INVALID"},{"name":"reconnectType","value":"TIMEOUT"}, {"name":"reconnectTime","value":"***"}]
- [{"name":"errorType","value":"SESSION_INVALID"},{"name":"reconnectType","value":"IMMEDIATE"}]
- [{"name":"errorType","value":"SESSION_INVALID"},{"name":"reconnectType","value":"TIMEOUT"}, {"name":"reconnectTime","value":"***"}]

For reconnectTime timestamp should be used

## Related Issue (for external contributions)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Related Ticket (for Inworld.ai developers)

<!--- Please link to the ticket here: -->

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
