### PR TITLE
feat: Make connection close method to be asynchronous

### DIFF
--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+
+- Await for CLOSED WebSocket connection state after CLOSING one
+
 ## [2.7.1] - 2024-06-27
 
 ### Fixed

--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Await for CLOSED WebSocket connection state after CLOSING one
+- Allow to change scene user parameters
 
 ## [2.7.1] - 2024-06-27
 

--- a/packages/web-core/src/common/data_structures.ts
+++ b/packages/web-core/src/common/data_structures.ts
@@ -236,6 +236,7 @@ export interface HistoryChangedProps<HistoryItemT = HistoryItem> {
 export interface ChangeSceneProps {
   capabilities?: Capabilities;
   sessionContinuation?: SessionContinuationProps;
+  user?: User;
   gameSessionId?: string;
 }
 

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -182,10 +182,10 @@ export class ConnectionService<
     }
   }
 
-  close() {
+  async close() {
     this.cancelScheduler();
     this.state = ConnectionState.INACTIVE;
-    this.connection.close();
+    await this.connection.close();
     this.clearQueue();
   }
 

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -291,6 +291,9 @@ export class ConnectionService<
         ...(props?.gameSessionId && {
           gameSessionId: props.gameSessionId,
         }),
+        ...(props?.user && {
+          user: props.user,
+        }),
       },
       sessionContinuation: props?.sessionContinuation
         ? new SessionContinuation(props.sessionContinuation)

--- a/packages/web-core/src/services/inworld_connection.service.ts
+++ b/packages/web-core/src/services/inworld_connection.service.ts
@@ -279,7 +279,7 @@ export class InworldConnectionService<
   }
 
   async changeScene(name: string, props?: ChangeSceneProps) {
-    if (!sceneHasValidFormat(name)) {
+    if (!sceneHasValidFormat(name) && !characterHasValidFormat(name)) {
       throw Error(SCENE_HAS_INVALID_FORMAT);
     }
 

--- a/packages/web-core/src/services/inworld_connection.service.ts
+++ b/packages/web-core/src/services/inworld_connection.service.ts
@@ -90,10 +90,10 @@ export class InworldConnectionService<
   }
 
   async close() {
-    this.connection.close();
+    this.player.clear();
     this.recorder.stop();
     await this.player.stop();
-    this.player.clear();
+    await this.connection.close();
   }
 
   isActive() {


### PR DESCRIPTION
## Description

- Await for CLOSED WebSocket connection state after CLOSING one
- Allow to change scene user parameters

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-1879
https://inworldai.atlassian.net/browse/INTG-1880

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
