### PR TITLE
feat: Allow to validate sent packets using zod

### DIFF
--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Improve connection management
 
+### Fixed
+
+- Fix regenration of expired token
+
 ## [2.8.0] - 2024-08-13
 
 ### Fixed

--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Server to Client log events
 - Latency reporting support
 - S2C logs added to conversation history
+- Allow to validate sent packets using zod
 
 ### Changed
 

--- a/packages/web-core/CHANGELOG.md
+++ b/packages/web-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fix regenration of expired token
+- Wait for one-to-one conversation loading on data sending
 
 ## [2.8.0] - 2024-08-13
 

--- a/packages/web-core/__tests__/connection/web-socket.connection.spec.ts
+++ b/packages/web-core/__tests__/connection/web-socket.connection.spec.ts
@@ -67,6 +67,7 @@ const createWebSocket = (props: {
     onReady,
     onMessage: props.onMessage || onMessage,
     onDisconnect,
+    eventFactory,
   });
 };
 
@@ -473,6 +474,7 @@ describe('open', () => {
       onReady,
       onMessage,
       onDisconnect,
+      eventFactory,
     });
     jest.spyOn(WebSocket.prototype, 'send').mockImplementation(jest.fn());
 

--- a/packages/web-core/__tests__/factories/event.spec.ts
+++ b/packages/web-core/__tests__/factories/event.spec.ts
@@ -299,7 +299,7 @@ describe('event types', () => {
   });
 
   test('should generate session control capabilities', () => {
-    const event = EventFactory.sessionControl({
+    const event = factory.sessionControl({
       capabilities: capabilitiesProps,
     });
 
@@ -317,7 +317,7 @@ describe('event types', () => {
 
   test('should generate session control session configuration', () => {
     const sessionConfiguration = { gameSessionId: v4() };
-    const event = EventFactory.sessionControl({ sessionConfiguration });
+    const event = factory.sessionControl({ sessionConfiguration });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -337,7 +337,7 @@ describe('event types', () => {
       version: v4(),
       description: v4(),
     };
-    const event = EventFactory.sessionControl({ clientConfiguration });
+    const event = factory.sessionControl({ clientConfiguration });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -357,7 +357,7 @@ describe('event types', () => {
       fullName: v4(),
       profile: { fields: [{ id: v4(), value: v4() }] },
     };
-    const event = EventFactory.sessionControl({ userConfiguration });
+    const event = factory.sessionControl({ userConfiguration });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -384,7 +384,7 @@ describe('event types', () => {
       continuationType:
         ContinuationContinuationType.CONTINUATION_TYPE_DIALOG_HISTORY,
     };
-    const event = EventFactory.sessionControl({ continuation });
+    const event = factory.sessionControl({ continuation });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -404,7 +404,7 @@ describe('event types', () => {
       continuationType:
         ContinuationContinuationType.CONTINUATION_TYPE_EXTERNALLY_SAVED_STATE,
     };
-    const event = EventFactory.sessionControl({ continuation });
+    const event = factory.sessionControl({ continuation });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -420,7 +420,7 @@ describe('event types', () => {
 
   test('should generate session control history', () => {
     const sessionHistory = {};
-    const event = EventFactory.sessionControl({ sessionHistory });
+    const event = factory.sessionControl({ sessionHistory });
 
     expect(event).toHaveProperty('routing');
     expect(event).toHaveProperty('timestamp');
@@ -434,7 +434,7 @@ describe('event types', () => {
 
   test('should generate conversation start event', () => {
     const characters = [v4(), v4()];
-    const event = EventFactory.conversation(characters, {
+    const event = factory.conversation(characters, {
       conversationId,
     });
     expect(event.control?.action).toEqual(

--- a/packages/web-core/__tests__/services/entity.service.spec.ts
+++ b/packages/web-core/__tests__/services/entity.service.spec.ts
@@ -33,7 +33,10 @@ beforeEach(() => {
 });
 
 test('should create or update items', async () => {
-  const createOrUpdateItems = jest.spyOn(EventFactory, 'createOrUpdateItems');
+  const createOrUpdateItems = jest.spyOn(
+    EventFactory.prototype,
+    'createOrUpdateItems',
+  );
 
   const items = [
     {
@@ -67,7 +70,7 @@ test('should create or update items', async () => {
 });
 
 test('should remove items', async () => {
-  const removeItems = jest.spyOn(EventFactory, 'removeItems');
+  const removeItems = jest.spyOn(EventFactory.prototype, 'removeItems');
 
   const ids = [v4(), v4()];
 
@@ -82,7 +85,7 @@ test.each([
   ItemsInEntitiesOperationType.REMOVE,
   ItemsInEntitiesOperationType.REPLACE,
 ])('shout execute $type', async (type) => {
-  const itemsInEntities = jest.spyOn(EventFactory, 'itemsInEntities');
+  const itemsInEntities = jest.spyOn(EventFactory.prototype, 'itemsInEntities');
 
   const itemIds = [v4(), v4()];
   const entityNames = [v4(), v4()];

--- a/packages/web-core/__tests__/services/inworld_connection.service.spec.ts
+++ b/packages/web-core/__tests__/services/inworld_connection.service.spec.ts
@@ -1287,16 +1287,10 @@ describe('character', () => {
   test('should set current character', async () => {
     jest
       .spyOn(service, 'getCurrentCharacter')
-      .mockImplementationOnce(() => Promise.resolve(undefined!));
-    const setCurrentCharacter = jest
-      .spyOn(eventFactory, 'setCurrentCharacter')
-      .mockImplementation(jest.fn());
+      .mockImplementationOnce(() => Promise.resolve(characters[0]!));
     const updateParticipants = jest
       .spyOn(ConversationService.prototype, 'updateParticipants')
       .mockImplementation(jest.fn());
-
-    await service.setCurrentCharacter(characters[0]);
-    expect(setCurrentCharacter.mock.calls[0][0]).toEqual(characters[0]);
 
     const conversationService = await service.getCurrentConversation();
 

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "base64-arraybuffer": "^1.0.2",
     "defer-promise": "^3.0.0",
+    "snakecase-keys": "^8.0.1",
     "uuid": "^9.0.0",
     "zod": "^3.23.8"
   }

--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inworld/web-core",
-  "version": "2.9.0-beta.8",
+  "version": "2.9.0-beta.9",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/web-core/src/common/data_structures.ts
+++ b/packages/web-core/src/common/data_structures.ts
@@ -224,6 +224,12 @@ export enum ConversationState {
   INACTIVE = 'INACTIVE',
 }
 
+export enum ConversationIntializeState {
+  ACTIVE = 'ACTIVE',
+  PROCESSING = 'PROCESSING',
+  INACTIVE = 'INACTIVE',
+}
+
 export interface PacketQueueItem {
   getPacket: () => ProtoPacket;
   afterWriting: (packet: ProtoPacket) => void;

--- a/packages/web-core/src/common/data_structures.ts
+++ b/packages/web-core/src/common/data_structures.ts
@@ -108,6 +108,7 @@ export interface ClientConfiguration {
   capabilities?: Capabilities;
   audioPlayback?: AudioPlaybackConfig;
   history?: HistoryConfig;
+  validateData?: boolean;
 }
 
 export interface InternalClientConfiguration {
@@ -116,6 +117,7 @@ export interface InternalClientConfiguration {
   capabilities: CapabilitiesConfiguration;
   audioPlayback?: AudioPlaybackConfig;
   history?: HistoryConfig;
+  validateData?: boolean;
 }
 
 export interface CancelResponses {

--- a/packages/web-core/src/connection/web-socket.connection.ts
+++ b/packages/web-core/src/connection/web-socket.connection.ts
@@ -28,6 +28,7 @@ import { EventFactory } from '../factories/event';
 
 const INWORLD_USER_ID = 'inworldUserId';
 const SESSION_PATH = '/v1/session/open';
+const NORMAL_CLOSURE_CODE = 1000;
 
 interface OpenSessionProps {
   name: string;
@@ -208,7 +209,7 @@ export class WebSocketConnection<
 
   async close(): Promise<void> {
     if (this.isActive()) {
-      this.ws.close();
+      this.ws.close(NORMAL_CLOSURE_CODE, 'Client closed the connection');
       this.connectionProps.onDisconnect();
     }
 

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -88,7 +88,7 @@ export class ConnectionService<
   private connection: Connection<InworldPacketT>;
   private connectionProps: ConnectionProps<InworldPacketT, HistoryItemT>;
 
-  private eventFactory = new EventFactory();
+  private eventFactory: EventFactory;
   private intervals: NodeJS.Timeout[] = [];
   private packetQueue: QueueItem<InworldPacketT>[] = [];
   private packetQueuePercievedLatency: InworldPacketT[] = [];
@@ -139,6 +139,9 @@ export class ConnectionService<
       user: this.connectionProps.user,
       scene: this.scene.name,
       conversations: this.conversations,
+    });
+    this.eventFactory = new EventFactory({
+      validateData: this.connectionProps.config?.validateData,
     });
 
     // Bind handlers
@@ -902,6 +905,7 @@ export class ConnectionService<
       onError: this.onError,
       onMessage: this.onMessage,
       extension: this.extension,
+      eventFactory: this.eventFactory,
     });
   }
 

--- a/packages/web-core/src/services/connection.service.ts
+++ b/packages/web-core/src/services/connection.service.ts
@@ -474,7 +474,7 @@ export class ConnectionService<
       // Reuse session id to keep context of previous conversation
       if (sessionId) {
         sessionToken = {
-          ...this.session,
+          ...sessionToken,
           sessionId,
         };
       }

--- a/packages/web-core/src/services/conversation.service.ts
+++ b/packages/web-core/src/services/conversation.service.ts
@@ -17,7 +17,6 @@ import {
 import { MULTI_CHAR_NARRATED_ACTIONS } from '../common/errors';
 import { Character } from '../entities/character.entity';
 import { InworldPacket } from '../entities/packets/inworld_packet.entity';
-import { EventFactory } from '../factories/event';
 import { ConnectionService } from './connection.service';
 
 export interface PacketQueueItem<
@@ -135,7 +134,7 @@ export class ConversationService<
     }
 
     const sent = await this.connection.send(() =>
-      EventFactory.conversation(conversationParticipants, {
+      this.connection.getEventFactory().conversation(conversationParticipants, {
         conversationId: this.getConversationId(),
       }),
     );
@@ -320,7 +319,7 @@ export class ConversationService<
       conversationParticipants.push(ConversationParticipant.USER);
     }
     const conversationPacket = await this.connection.send(() =>
-      EventFactory.conversation(conversationParticipants, {
+      this.connection.getEventFactory().conversation(conversationParticipants, {
         conversationId: this.getConversationId(),
       }),
     );

--- a/packages/web-core/src/services/entity.service.ts
+++ b/packages/web-core/src/services/entity.service.ts
@@ -4,7 +4,6 @@ import {
 } from '../common/data_structures';
 import { EntityItem } from '../entities/entities/entity_item';
 import { InworldPacket } from '../entities/packets/inworld_packet.entity';
-import { EventFactory } from '../factories/event';
 import { ConnectionService } from './connection.service';
 
 export class EntityService<
@@ -21,7 +20,7 @@ export class EntityService<
     addToEntities: string[];
   }) {
     return this.connection.send(() =>
-      EventFactory.createOrUpdateItems({
+      this.connection.getEventFactory().createOrUpdateItems({
         items: props.items.map((item) => new EntityItem(item)),
         addToEntities: props.addToEntities,
       }),
@@ -29,7 +28,9 @@ export class EntityService<
   }
 
   async removeItems(ids: string[]) {
-    return this.connection.send(() => EventFactory.removeItems(ids));
+    return this.connection.send(() =>
+      this.connection.getEventFactory().removeItems(ids),
+    );
   }
 
   async itemsInEntities(props: {
@@ -37,6 +38,8 @@ export class EntityService<
     itemIds: string[];
     entityNames: string[];
   }) {
-    return this.connection.send(() => EventFactory.itemsInEntities(props));
+    return this.connection.send(() =>
+      this.connection.getEventFactory().itemsInEntities(props),
+    );
   }
 }

--- a/packages/web-core/src/services/inworld_connection.service.ts
+++ b/packages/web-core/src/services/inworld_connection.service.ts
@@ -21,7 +21,6 @@ import { InworldRecorder } from '../components/sound/inworld_recorder';
 import { Character } from '../entities/character.entity';
 import { InworldError } from '../entities/error.entity';
 import { InworldPacket } from '../entities/packets/inworld_packet.entity';
-import { EventFactory } from '../factories/event';
 import { characterHasValidFormat, sceneHasValidFormat } from '../guard/scene';
 import { ConnectionService } from './connection.service';
 import { ConversationService } from './conversation.service';
@@ -305,7 +304,7 @@ export class InworldConnectionService<
     }
 
     const result = await this.connection.send(() =>
-      EventFactory.loadCharacters(names),
+      this.connection.getEventFactory().loadCharacters(names),
     );
 
     await this.resolveInterval(() => {
@@ -329,7 +328,7 @@ export class InworldConnectionService<
       .map((c) => c.id);
 
     const result = await this.connection.send(() =>
-      EventFactory.unloadCharacters(ids),
+      this.connection.getEventFactory().unloadCharacters(ids),
     );
 
     this.connection.removeCharacters(names);

--- a/packages/web-core/src/services/inworld_connection.service.ts
+++ b/packages/web-core/src/services/inworld_connection.service.ts
@@ -4,6 +4,7 @@ import {
   AudioSessionState,
   CancelResponsesProps,
   ChangeSceneProps,
+  ConversationIntializeState,
   ConversationParticipant,
   ConversationState,
   TriggerParameter,
@@ -44,6 +45,8 @@ export class InworldConnectionService<
   private connection: ConnectionService<InworldPacketT>;
   private grpcAudioPlayer: GrpcAudioPlayback<InworldPacketT>;
   private oneToOneConversation: ConversationService<InworldPacketT>;
+  private oneToOneConversationIntializeState =
+    ConversationIntializeState.INACTIVE;
 
   readonly feedback: FeedbackService<InworldPacketT>;
   readonly entity: EntityService<InworldPacketT>;
@@ -379,7 +382,12 @@ export class InworldConnectionService<
   }
 
   private async ensureOneToOneConversation() {
-    if (!this.oneToOneConversation) {
+    if (
+      this.oneToOneConversationIntializeState ===
+      ConversationIntializeState.INACTIVE
+    ) {
+      this.oneToOneConversationIntializeState =
+        ConversationIntializeState.PROCESSING;
       const character = await this.getCurrentCharacter();
 
       if (!character) {
@@ -395,6 +403,23 @@ export class InworldConnectionService<
       );
 
       this.addConversationToConnection(this.oneToOneConversation);
+      this.oneToOneConversationIntializeState =
+        ConversationIntializeState.ACTIVE;
+    } else {
+      return new Promise<void>((resolve) => {
+        const interval = setInterval(() => {
+          if (
+            this.oneToOneConversationIntializeState ===
+            ConversationIntializeState.ACTIVE
+          ) {
+            clearInterval(interval);
+            this.connection.removeInterval(interval);
+            resolve();
+          }
+        }, 10);
+
+        this.connection.addInterval(interval);
+      });
     }
   }
 

--- a/packages/web-core/src/zod/schema.ts
+++ b/packages/web-core/src/zod/schema.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { RoutingSchema } from "../../zod/routing";
+import { LatencyReportEventSchema, PacketIdSchema } from "../../zod/latency_report_event";
+import { TextEventSchema } from "../../zod/text_event";
+import { ControlEventSchema } from "../../zod/control_event";
+import { CustomEventSchema } from "../../zod/custom_event";
+import { CancelResponsesEventSchema } from "../../zod/cancel_responses_event";
+import { EmotionEventSchema } from "../../zod/emotion_event";
+import { DataChunkSchema } from "../../zod/data_chunk";
+import { ActionEventSchema } from "../../zod/action_event";
+import { MutationEventSchema } from "../../zod/mutation_event";
+import { SessionControlEventSchema } from "../../zod/session_control_event";
+import { ItemsOperationEventSchema } from "../../zod/items_operation_event";
+
+export const InworldPacketSchema = z.object({
+	timestamp: z.coerce.date().optional(),
+	routing: RoutingSchema.optional(),
+	packetId: PacketIdSchema.optional(),
+	text: TextEventSchema.optional(),
+	control: ControlEventSchema.optional(),
+	custom: CustomEventSchema.optional(),
+	cancelResponses: CancelResponsesEventSchema.optional(),
+	emotion: EmotionEventSchema.optional(),
+	dataChunk: DataChunkSchema.optional(),
+	action: ActionEventSchema.optional(),
+	mutation: MutationEventSchema.optional(),
+	sessionControl: SessionControlEventSchema.optional(),
+	latencyReport: LatencyReportEventSchema.optional(),
+	entitiesItemsOperation: ItemsOperationEventSchema.optional(),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,6 +535,7 @@ __metadata:
     "@types/uuid": "npm:^9.0.0"
     base64-arraybuffer: "npm:^1.0.2"
     defer-promise: "npm:^3.0.0"
+    snakecase-keys: "npm:^8.0.1"
     tsc-alias: "npm:^1.8.8"
     uuid: "npm:^9.0.0"
     zod: "npm:^3.23.8"
@@ -2923,6 +2924,16 @@ __metadata:
   dependencies:
     webidl-conversions: "npm:^7.0.0"
   checksum: 10c0/774277cd9d4df033f852196e3c0077a34dbd15a96baa4d166e0e47138a80f4c0bdf0d94e4703e6ff5883cec56bb821a6fff84402d8a498e31de7c87eb932a294
+  languageName: node
+  linkType: hard
+
+"dot-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "dot-case@npm:3.0.4"
+  dependencies:
+    no-case: "npm:^3.0.4"
+    tslib: "npm:^2.0.3"
+  checksum: 10c0/5b859ea65097a7ea870e2c91b5768b72ddf7fa947223fd29e167bcdff58fe731d941c48e47a38ec8aa8e43044c8fbd15cd8fa21689a526bc34b6548197cd5b05
   languageName: node
   linkType: hard
 
@@ -5686,6 +5697,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lower-case@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "lower-case@npm:2.0.2"
+  dependencies:
+    tslib: "npm:^2.0.3"
+  checksum: 10c0/3d925e090315cf7dc1caa358e0477e186ffa23947740e4314a7429b6e62d72742e0bbe7536a5ae56d19d7618ce998aba05caca53c2902bd5742fdca5fc57fd7b
+  languageName: node
+  linkType: hard
+
 "lowercase-keys@npm:^3.0.0":
   version: 3.0.0
   resolution: "lowercase-keys@npm:3.0.0"
@@ -5781,6 +5801,13 @@ __metadata:
   dependencies:
     tmpl: "npm:1.0.5"
   checksum: 10c0/b0e6e599780ce6bab49cc413eba822f7d1f0dfebd1c103eaa3785c59e43e22c59018323cf9e1708f0ef5329e94a745d163fcbb6bff8e4c6742f9be9e86f3500c
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "map-obj@npm:4.3.0"
+  checksum: 10c0/1c19e1c88513c8abdab25c316367154c6a0a6a0f77e3e8c391bb7c0e093aefed293f539d026dc013d86219e5e4c25f23b0003ea588be2101ccd757bacc12d43b
   languageName: node
   linkType: hard
 
@@ -6078,6 +6105,16 @@ __metadata:
   dependencies:
     type-fest: "npm:^2.5.1"
   checksum: 10c0/9faec009b8b403efbc407f45306d07de5cc58e09df5b00bdd55b01384cd18b0fd29a97aef6915428ba3b5abb0a5c132c3507468c0c3c101e8d737c1337386786
+  languageName: node
+  linkType: hard
+
+"no-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "no-case@npm:3.0.4"
+  dependencies:
+    lower-case: "npm:^2.0.2"
+    tslib: "npm:^2.0.3"
+  checksum: 10c0/8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
   languageName: node
   linkType: hard
 
@@ -7337,6 +7374,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"snake-case@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "snake-case@npm:3.0.4"
+  dependencies:
+    dot-case: "npm:^3.0.4"
+    tslib: "npm:^2.0.3"
+  checksum: 10c0/ab19a913969f58f4474fe9f6e8a026c8a2142a01f40b52b79368068343177f818cdfef0b0c6b9558f298782441d5ca8ed5932eb57822439fad791d866e62cecd
+  languageName: node
+  linkType: hard
+
+"snakecase-keys@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "snakecase-keys@npm:8.0.1"
+  dependencies:
+    map-obj: "npm:^4.1.0"
+    snake-case: "npm:^3.0.4"
+    type-fest: "npm:^4.15.0"
+  checksum: 10c0/3615126462e413fe5e1637c945362e99c3ac497bc49d867397547ab1a87ff2827ae890d1aa022ef06c27cb3924bcb3714db2f4e76770e6ebd3625f3e16d79d27
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.2":
   version: 8.0.2
   resolution: "socks-proxy-agent@npm:8.0.2"
@@ -7804,6 +7862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.3":
+  version: 2.8.0
+  resolution: "tslib@npm:2.8.0"
+  checksum: 10c0/31e4d14dc1355e9b89e4d3c893a18abb7f90b6886b089c2da91224d0a7752c79f3ddc41bc1aa0a588ac895bd97bb99c5bc2bfdb2f86de849f31caeb3ba79bbe5
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -7845,6 +7910,13 @@ __metadata:
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.15.0":
+  version: 4.26.1
+  resolution: "type-fest@npm:4.26.1"
+  checksum: 10c0/d2719ff8d380befe8a3c61068f37f28d6fa2849fd140c5d2f0f143099e371da6856aad7c97e56b83329d45bfe504afe9fd936a7cff600cc0d46aa9ffb008d6c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

When validateData property is set as true and sent packet has a wrong format (based on ts files generated from proto), you will see a warn on browser console with details what's wrong

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-2151

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
