### PR TITLE
chore: Make CHANGELOG version validation to be optional during release action

### DIFF
--- a/packages/web-core/.release-it.json
+++ b/packages/web-core/.release-it.json
@@ -24,7 +24,8 @@
   },
   "plugins": {
     "@release-it/keep-a-changelog": {
-      "filename": "CHANGELOG.md"
+      "filename": "CHANGELOG.md",
+      "strictLatest": false
     }
   }
 }

--- a/packages/web-threejs/.release-it.json
+++ b/packages/web-threejs/.release-it.json
@@ -23,7 +23,8 @@
   },
   "plugins": {
     "@release-it/keep-a-changelog": {
-      "filename": "CHANGELOG.md"
+      "filename": "CHANGELOG.md",
+      "strictLatest": false
     }
   }
 }


### PR DESCRIPTION
## Description

Otherwise, it doesn't work because of beta-releases
I don't want intermediate sections for beta-release in CHANGELOG, so for now we'll omit version validation

## Related Ticket (for Inworld.ai developers)

https://inworldai.atlassian.net/browse/INTG-2220

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
