### PR TITLE
fix: Revert to previous format of latency as a string

### DIFF
--- a/packages/web-core/package.json
+++ b/packages/web-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inworld/web-core",
-  "version": "2.10.0-beta.0",
+  "version": "2.10.0-beta.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/web-core/src/common/helpers.ts
+++ b/packages/web-core/src/common/helpers.ts
@@ -38,5 +38,5 @@ export const calculateTimeDifference = (from: Date, to: Date) => {
     nanos += 1000000000;
   }
 
-  return { seconds, nanos };
+  return `${(seconds + nanos / 1000000000).toFixed(9)}s`;
 };


### PR DESCRIPTION
## Description

Grpc gateway accept latency as a string only
Otherwise it returns an error
Reverted to previous behaviour

## Related Issue (for external contributions)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Related Ticket (for Inworld.ai developers)

<!--- Please link to the ticket here: -->

## Screenshots (if appropriate)

## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
